### PR TITLE
Add support for Heroku-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ $ bundle exec rake upload[2.2.2,cedar-14]
 When a new Ruby version releases you will want to build support for all stacks.
 
 ```sh
+bundle exec rake new[2.6.0,heroku-20] && \
+bash rubies/heroku-18/ruby-2.6.0.sh && \
+bundle exec rake upload[2.6.0,heroku-20] && \
+bundle exec rake test[2.6.0,heroku-20] && \
+\
 bundle exec rake new[2.6.0,heroku-18] && \
 bash rubies/heroku-18/ruby-2.6.0.sh && \
 bundle exec rake upload[2.6.0,heroku-18] && \
@@ -104,7 +109,7 @@ bash rubies/cedar-14/ruby-2.6.0.sh && \
 bundle exec rake upload[2.6.0,cedar-14] && \
 bundle exec rake test[2.6.0,cedar-14] && \
 \
-echo "Done building 2.6.0 for cedar-14, heroku-16, and heroku-18"
+echo "Done building 2.6.0 for cedar-14, heroku-16, heroku-18 and heroku-20"
 ```
 
 #### Building a GIT_URL release

--- a/dockerfiles/Dockerfile.heroku-20
+++ b/dockerfiles/Dockerfile.heroku-20
@@ -1,0 +1,10 @@
+FROM heroku/heroku:20-build
+
+# setup workspace
+RUN rm -rf /tmp/workspace
+RUN mkdir -p /tmp/workspace
+
+# output dir is mounted
+
+ADD build.rb /tmp/build.rb
+CMD ["ruby", "/tmp/build.rb", "/tmp/workspace", "/tmp/output", "/tmp/cache"]

--- a/rubies/heroku-20/ruby-2.4.10.sh
+++ b/rubies/heroku-20/ruby-2.4.10.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=2.4.10  -e STACK=heroku-20 hone/ruby-builder:heroku-20

--- a/rubies/heroku-20/ruby-2.4.10.sh
+++ b/rubies/heroku-20/ruby-2.4.10.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-source `dirname $0`/../common.sh
-
-docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=2.4.10  -e STACK=heroku-20 hone/ruby-builder:heroku-20

--- a/rubies/heroku-20/ruby-2.5.8.sh
+++ b/rubies/heroku-20/ruby-2.5.8.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=2.5.8  -e STACK=heroku-20 hone/ruby-builder:heroku-20

--- a/rubies/heroku-20/ruby-2.6.6.sh
+++ b/rubies/heroku-20/ruby-2.6.6.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=2.6.6  -e STACK=heroku-20 hone/ruby-builder:heroku-20

--- a/rubies/heroku-20/ruby-2.7.1.sh
+++ b/rubies/heroku-20/ruby-2.7.1.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=2.7.1  -e STACK=heroku-20 hone/ruby-builder:heroku-20


### PR DESCRIPTION
The Dockerfile was based on [the one for Heroku-18](https://github.com/heroku/docker-heroku-ruby-builder/blob/6d12d5d0da508ae94d1de614c525beba5b4192eb/dockerfiles/Dockerfile.heroku-18), except with the `apt-get install` step removed, since:
* `autoconf` and `zip` are already in the base image ([installed packages](https://github.com/heroku/stack-images/blob/5aa96ad255161ebbc75a18934c8e024937618b94/heroku-20-build/installed-packages.txt))
* `subversion` is only used when `SVN_URL` is set in the build script, which is only required for Ruby < 2.0.

The build scripts were generated using `rake new[<version>,heroku-20]`, and I added one for each of the [latest versions](https://www.ruby-lang.org/en/downloads/releases/) of Ruby ~2.4~ 2.5 to 2.7.

~I included Ruby 2.4 even though it's [no longer maintained](https://www.ruby-lang.org/en/downloads/branches/), since the EOL date was only 2 weeks ago, and it includes the same security fixes as all of the other maintained branches (ie: until there is another CVE announced, it doesn't contain any known vulnerabilities). Including it will ease the stack upgrade path for customers, given the difficulty we've seen with the Cedar-14 EOL and customers trying to simultaneously update stack+Ruby+Rails versions.~

It's worth noting that for now, the `rake test` of Heroku-20 will fail, since the new stack is marked as internal-only, so needs a privileged API call to create the app with that stack. I've tested the build scripts locally however.

Refs [W-7457565](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007QfR8IAK/view).