### PR TITLE
Build Ruby 3.1.1 for heroku-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This build tool supports heroku's multiple stacks. The built rubies will go in t
 First we'll need to generate the docker images needed for building the appropriate stack.
 
 ```sh
-$ bundle exec rake generate_image[cedar-14]
+$ bundle exec rake "generate_image[cedar-14]"
 ```
 
 Generate a ruby build script:

--- a/dockerfiles/Dockerfile.heroku-22
+++ b/dockerfiles/Dockerfile.heroku-22
@@ -1,0 +1,12 @@
+FROM heroku/heroku:22-build
+
+# setup workspace
+RUN rm -rf /tmp/workspace
+RUN mkdir -p /tmp/workspace
+
+RUN apt-get update -y; apt-get install ruby -y
+
+# output dir is mounted
+
+ADD build.rb /tmp/build.rb
+CMD ["ruby", "/tmp/build.rb", "/tmp/workspace", "/tmp/output", "/tmp/cache"]

--- a/rubies/heroku-18/ruby-3.1.1.sh
+++ b/rubies/heroku-18/ruby-3.1.1.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=3.1.1  -e STACK=heroku-18 hone/ruby-builder:heroku-18

--- a/rubies/heroku-20/ruby-3.1.1.sh
+++ b/rubies/heroku-20/ruby-3.1.1.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=3.1.1  -e STACK=heroku-20 hone/ruby-builder:heroku-20

--- a/rubies/heroku-22/ruby-3.1.0.sh
+++ b/rubies/heroku-22/ruby-3.1.0.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=3.1.0  -e STACK=heroku-22 hone/ruby-builder:heroku-22

--- a/rubies/heroku-22/ruby-3.1.1.sh
+++ b/rubies/heroku-22/ruby-3.1.1.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=3.1.1  -e STACK=heroku-22 hone/ruby-builder:heroku-22


### PR DESCRIPTION
The big thing needed here is that heroku-22 no longer has a default version of ruby. In the docker image we need a Ruby version so we can execute `build.rb`. We get it by executing `RUN apt-get update -y; apt-get install ruby -y`

Ruby 3.0.x and 2.7.x cannot build on heroku-22 due to https://bugs.ruby-lang.org/issues/18658