### PR TITLE
Switch away from deprecated path-based S3 URLs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -127,7 +127,7 @@ task :test, [:version, :stack, :staging] do |t, args|
 
   if staging
     buildpacks = ["https://github.com/sharpstone/sudo_set_config_var_buildpack", "heroku/ruby"]
-    config = {"__SUDO_BUILDPACK_VENDOR_URL" => "https://heroku-buildpack-ruby-staging.s3.amazonaws.com"}
+    config = {"__SUDO_BUILDPACK_VENDOR_URL" => "https://heroku-buildpack-ruby-staging.s3.us-east-1.amazonaws.com"}
   else
     buildpacks = ["heroku/ruby"]
     config = {}

--- a/build.rb
+++ b/build.rb
@@ -45,7 +45,9 @@ cache_dir     = ARGV[2]
 LIBYAML_VERSION = "0.1.7"
 LIBFFI_VERSION  = "3.2.1"
 
-vendor_url   = "https://s3.amazonaws.com/#{ENV['S3_BUCKET_NAME'] ? ENV['S3_BUCKET_NAME'] : 'heroku-buildpack-ruby'}"
+s3_bucket_name = ENV.fetch('S3_BUCKET_NAME', 'heroku-buildpack-ruby')
+s3_bucket_region = ENV.fetch('S3_BUCKET_REGION', 'us-east-1')
+vendor_url   = "https://#{s3_bucket_name}.s3.#{s3_bucket_region}.amazonaws.com"
 full_version = ENV['VERSION']
 full_name    = "ruby-#{full_version}"
 version      = full_version.split('-').first


### PR DESCRIPTION
S3 URLs where the bucket name is part of the URL path are deprecated.

Instead, it's recommended to use the virtual-hosted style references, where the bucket name is part of the domain. 

The latter allows AWS to use DNS to direct requests directly to the appropriate region's S3 endpoint, rather than having to route via the global S3 endpoint (which AWS describe as being a single point of failure/harder to scale etc).

See:
https://github.com/heroku/heroku-buildpack-ruby/pull/1311
https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397. 