### PR TITLE
Ruby 3.2.0-preview3 with yjit support

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -160,6 +160,8 @@ Dir.mktmpdir("ruby-vendor-") do |vendor_dir|
 
     configure_opts = "--disable-install-doc --prefix #{prefix}"
     configure_opts += " --enable-load-relative" if major_ruby != "1.8" && version != "1.9.2"
+    configure_opts += " --enable-yjit" if Gem::Version.new(version) >= Gem::Version.new("3.2")
+
     if stack != "cedar-14"
       configure_opts += " --enable-shared"
     end

--- a/dockerfiles/Dockerfile.heroku-18
+++ b/dockerfiles/Dockerfile.heroku-18
@@ -2,6 +2,8 @@ FROM heroku/heroku:18-build.v16
 MAINTAINER hone
 
 RUN apt-get update && apt-get install autoconf subversion zip -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # setup workspace
 RUN rm -rf /tmp/workspace

--- a/dockerfiles/Dockerfile.heroku-20
+++ b/dockerfiles/Dockerfile.heroku-20
@@ -4,6 +4,9 @@ FROM heroku/heroku:20-build
 RUN rm -rf /tmp/workspace
 RUN mkdir -p /tmp/workspace
 
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # output dir is mounted
 
 ADD build.rb /tmp/build.rb

--- a/dockerfiles/Dockerfile.heroku-22
+++ b/dockerfiles/Dockerfile.heroku-22
@@ -5,6 +5,8 @@ RUN rm -rf /tmp/workspace
 RUN mkdir -p /tmp/workspace
 
 RUN apt-get update -y; apt-get install ruby -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 # output dir is mounted
 

--- a/rubies/heroku-18/ruby-3.2.0-preview3.sh
+++ b/rubies/heroku-18/ruby-3.2.0-preview3.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=3.2.0-preview3  -e STACK=heroku-18 hone/ruby-builder:heroku-18

--- a/rubies/heroku-20/ruby-3.2.0-preview3.sh
+++ b/rubies/heroku-20/ruby-3.2.0-preview3.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=3.2.0-preview3  -e STACK=heroku-20 hone/ruby-builder:heroku-20

--- a/rubies/heroku-22/ruby-3.2.0-preview3.sh
+++ b/rubies/heroku-22/ruby-3.2.0-preview3.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source `dirname $0`/../common.sh
+
+docker run -v $OUTPUT_DIR:/tmp/output -v $CACHE_DIR:/tmp/cache -e VERSION=3.2.0-preview3  -e STACK=heroku-22 hone/ruby-builder:heroku-22


### PR DESCRIPTION
Yjit requires rustc when building but not at runtime.

GUS-W-11958486.