### PR TITLE
Fix ruby code bug:

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -72,7 +72,7 @@ else
 end
 
 # https://bugs.ruby-lang.org/issues/18658
-if stack == "heroku-22" && version.starts_with?("3.0")
+if stack == "heroku-22" && version.start_with?("3.0")
   raise "Cannot build Ruby 3.0 on heroku-22"
 end
 


### PR DESCRIPTION
```
$ ruby -e "puts 'ruby'.starts_with?('r')"
-e:1:in `<main>': undefined method `starts_with?' for "ruby":String (NoMethodError)

puts 'ruby'.starts_with?('r')
           ^^^^^^^^^^^^^
Did you mean?  start_with?
$ ruby -e "puts 'ruby'.start_with?('r')"
true
```

Added in last PR by mistake.