### PR TITLE
Install `libreadline-dev` on Heroku-24

### DIFF
--- a/dockerfiles/Dockerfile.heroku-24
+++ b/dockerfiles/Dockerfile.heroku-24
@@ -6,7 +6,7 @@ USER root
 RUN rm -rf /tmp/workspace
 RUN mkdir -p /tmp/workspace
 
-RUN apt-get update -y; apt-get install ruby -y
+RUN apt-get update -y && apt-get install -y libreadline-dev ruby
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 


### PR DESCRIPTION
Since it's no longer in the Heroku-24 build image after:
https://github.com/heroku/base-images/pull/296

(The headers are only needed when the Ruby runtimes are being compiled. The run image still has the necessary runtime library counterparts.)

See also:
https://github.com/heroku/heroku-buildpack-python/pull/1580