### PR TITLE
Add missing `--locked` to Cargo commands

### DIFF
--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -38,13 +38,13 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       - name: Cargo build
-        run: cargo build
+        run: cargo build --locked
       - name: Output CHANGELOG
-        run: cargo run --bin jruby_changelog -- --version "${{inputs.jruby_version}}"
+        run: cargo run --locked --bin jruby_changelog -- --version "${{inputs.jruby_version}}"
       - name: Build Ruby
-        run: cargo run --bin jruby_build -- --version ${{inputs.jruby_version}} --base-image ${{matrix.base_image}} \
+        run: cargo run --locked --bin jruby_build -- --version ${{inputs.jruby_version}} --base-image ${{matrix.base_image}} \
       - name: Check Ruby
-        run: cargo run --bin jruby_check -- --version ${{inputs.jruby_version}} --base-image ${{matrix.base_image}} --arch amd64 | tee $GITHUB_STEP_SUMMARY
+        run: cargo run --locked --bin jruby_check -- --version ${{inputs.jruby_version}} --base-image ${{matrix.base_image}} --arch amd64 | tee $GITHUB_STEP_SUMMARY
       - name: Upload Ruby runtime archive to S3 dry run
         if: (inputs.dry_run)
         run: aws s3 sync ./output "s3://${S3_BUCKET}" --dryrun

--- a/.github/workflows/build_ruby.yml
+++ b/.github/workflows/build_ruby.yml
@@ -43,13 +43,13 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       - name: Cargo build
-        run: cargo build
+        run: cargo build --locked
       - name: Output CHANGELOG
-        run: cargo run --bin ruby_changelog -- --version "${{inputs.ruby_version}}"
+        run: cargo run --locked --bin ruby_changelog -- --version "${{inputs.ruby_version}}"
       - name: Build Ruby
-        run: cargo run --bin ruby_build -- --version ${{inputs.ruby_version}} --base-image ${{matrix.base_image}} --arch ${{matrix.arch}}
+        run: cargo run --locked --bin ruby_build -- --version ${{inputs.ruby_version}} --base-image ${{matrix.base_image}} --arch ${{matrix.arch}}
       - name: Check Ruby
-        run: cargo run --bin ruby_check -- --version ${{inputs.ruby_version}} --base-image ${{matrix.base_image}} --arch  ${{matrix.arch}} | tee $GITHUB_STEP_SUMMARY
+        run: cargo run --locked --bin ruby_check -- --version ${{inputs.ruby_version}} --base-image ${{matrix.base_image}} --arch  ${{matrix.arch}} | tee $GITHUB_STEP_SUMMARY
       - name: Upload Ruby runtime archive to S3 dry run
         if: (inputs.dry_run)
         run: aws s3 sync ./output "s3://${S3_BUCKET}" --dryrun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,13 @@ jobs:
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       - name: Clippy
         # Using --all-targets so tests are checked and --deny to fail on warnings.
-        # Not using --locked here and below since Cargo.lock is in .gitignore.
-        run: cargo clippy --all-targets --all-features -- --deny warnings
+        run: cargo clippy --all-targets --all-features --locked -- --deny warnings
       - name: rustfmt
         run: cargo fmt -- --check
       - name: Check docs
         # Using RUSTDOCFLAGS until `cargo doc --check` is stabilised:
         # https://github.com/rust-lang/cargo/issues/10025
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --document-private-items --no-deps
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --document-private-items --no-deps --locked
 
   unit-test:
     runs-on: ubuntu-24.04
@@ -45,7 +44,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       - name: Run unit tests
-        run: cargo test --all-features
+        run: cargo test --all-features --locked
 
   ruby_integration_test:
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
@@ -67,13 +66,13 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       - name: Cargo build (to make test logs shorter)
-        run: cargo build
+        run: cargo build --locked
       - name: Output CHANGELOG
-        run: cargo run --bin ruby_changelog -- --version "${{matrix.version}}"
+        run: cargo run --locked --bin ruby_changelog -- --version "${{matrix.version}}"
       - name: Build Ruby
-        run: cargo run --bin ruby_build -- --version ${{matrix.version}} --base-image ${{matrix.base_image}} --arch ${{matrix.arch}}
+        run: cargo run --locked --bin ruby_build -- --version ${{matrix.version}} --base-image ${{matrix.base_image}} --arch ${{matrix.arch}}
       - name: Check Ruby
-        run: cargo run --bin ruby_check -- --version ${{matrix.version}} --base-image ${{matrix.base_image}} --arch ${{matrix.arch}}
+        run: cargo run --locked --bin ruby_check -- --version ${{matrix.version}} --base-image ${{matrix.base_image}} --arch ${{matrix.arch}}
 
   jruby_integration_test:
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
@@ -95,13 +94,13 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
       - name: Cargo build (to make test logs shorter)
-        run: cargo build
+        run: cargo build --locked
       - name: Output CHANGELOG
-        run: cargo run --bin jruby_changelog -- --version "${{matrix.version}}"
+        run: cargo run --locked --bin jruby_changelog -- --version "${{matrix.version}}"
       - name: Build JRuby
-        run: cargo run --bin jruby_build -- --version ${{matrix.version}} --base-image ${{matrix.base_image}}
+        run: cargo run --locked --bin jruby_build -- --version ${{matrix.version}} --base-image ${{matrix.base_image}}
       - name: Check JRuby
-        run: cargo run --bin jruby_check -- --version ${{matrix.version}} --base-image ${{matrix.base_image}} --arch ${{matrix.arch}}
+        run: cargo run --locked --bin jruby_check -- --version ${{matrix.version}} --base-image ${{matrix.base_image}} --arch ${{matrix.arch}}
 
   check_inventory_urls:
     runs-on: ubuntu-24.04
@@ -120,4 +119,4 @@ jobs:
           git fetch origin ${{ github.base_ref }} --depth 1 && \
           git diff --unified=0 remotes/origin/${{ github.base_ref }} ${{matrix.inventory}} | grep '^+' | grep -v '^+++' | cut -c2- > check_inventory.toml
       - name: Check manifest URLs
-        run: cargo run --bin inventory_check -- check_inventory.toml
+        run: cargo run --locked --bin inventory_check -- check_inventory.toml


### PR DESCRIPTION
The Cargo `--locked` argument ensures that Cargo will fail with an error if `Cargo.lock` is out of sync with `Cargo.toml`, rather than the lockfile being silently updated.

As such, in CI we should always be using `--locked` for projects that have committed their lockfile to Git (which should be the case for most projects other than those that are libraries).

After seeing that `cnb-otel-collector` didn't use `--locked` in all cases, I audited all of our Rust repos and found others missing `--locked` too.

GUS-W-18062544.