### PR TITLE
Check if JRuby binstub already exists

### DIFF
--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Output CHANGELOG
         run: cargo run --locked --bin jruby_changelog -- --version "${{inputs.jruby_version}}"
       - name: Build Ruby
-        run: cargo run --locked --bin jruby_build -- --version ${{inputs.jruby_version}} --base-image ${{matrix.base_image}} \
+        run: cargo run --locked --bin jruby_build -- --version ${{inputs.jruby_version}} --base-image ${{matrix.base_image}}
       - name: Check Ruby
         run: cargo run --locked --bin jruby_check -- --version ${{inputs.jruby_version}} --base-image ${{matrix.base_image}} --arch amd64 | tee $GITHUB_STEP_SUMMARY
       - name: Upload Ruby runtime archive to S3 dry run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "2.11.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
 dependencies = [
  "autocfg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ members = [
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [workspace.dependencies]
 bullet_stream = "0.2"
 chrono = {version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 flate2 = "1"
-fs-err = "2"
+fs-err = "3"
 fs2 = "0.4"
 fun_run = "0.2"
 gem_version = "0.3"

--- a/jruby_executable/src/bin/jruby_build.rs
+++ b/jruby_executable/src/bin/jruby_build.rs
@@ -93,10 +93,16 @@ fn jruby_build(args: &Args) -> Result<(), Box<dyn Error>> {
     };
 
     log = {
-        let bullet = log.bullet("Create ruby symlink to jruby");
-        fs_err::os::unix::fs::symlink("jruby", jruby_dir.join("bin/ruby"))?;
-
-        bullet.done()
+        let bullet = log.bullet("Checking for `ruby` binstub");
+        let ruby_bin = jruby_dir.join("bin").join("ruby");
+        if ruby_bin.fs_err_try_exists()? {
+            bullet.sub_bullet("File exists")
+        } else {
+            let sub = bullet.sub_bullet("Create ruby symlink to jruby");
+            fs_err::os::unix::fs::symlink("jruby", ruby_bin)?;
+            sub
+        }
+        .done()
     };
 
     let tgz_name = format!("ruby-{ruby_stdlib_version}-jruby-{version}.tgz");


### PR DESCRIPTION
It seems the upstream ruby started making a `ruby` binstub, so the symlink failed with an error:

```
- Create ruby symlink to jruby

! ❌ Command failed ❌
!
! failed to symlink file from jruby to /var/folders/yr/yytf3z3n3q336f1tj2b2j0gw0000gn/T/.tmpByM3Vk/extracted/jruby-10.0.1.0/bin/ruby
```

This is blocking the release of JRuby `10.0.1.0`

GUS-W-19086785
