### PR TITLE
Switch to GitHub Actions public `ubuntu-24.04-arm` runner

### DIFF
--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -54,7 +54,7 @@ jobs:
 
   after-build-and-upload:
     needs: build-and-upload
-    runs-on: pub-hk-ubuntu-24.04-xlarge
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - name: Update Jruby inventory file locally
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8

--- a/.github/workflows/build_ruby.yml
+++ b/.github/workflows/build_ruby.yml
@@ -57,7 +57,7 @@ jobs:
 
   after-build-and-upload:
     needs: build-and-upload
-    runs-on: pub-hk-ubuntu-24.04-xlarge
+    runs-on: pub-hk-ubuntu-24.04-ip
     steps:
       - name: Update Ruby inventory file locally
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo test --all-features --locked
 
   ruby_integration_test:
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         base_image: ["heroku-22", "heroku-24"]
@@ -73,7 +73,7 @@ jobs:
         run: cargo run --locked --bin ruby_check -- --version ${{matrix.version}} --base-image ${{matrix.base_image}} --arch ${{matrix.arch}}
 
   jruby_integration_test:
-    runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-medium' || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         base_image: ["heroku-22", "heroku-24"]


### PR DESCRIPTION
In January 2025, GitHub Actions announced preview support for public ARM GitHub Actions runners (previously only available when using the custom runners group feature):
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

The public runners were then GAed this month:
https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/

The Python CNB has been successfully using the public runners since then (in the first few weeks there was an issue with crashes due to the public runners using newer CPU model, but that's since been resolved).

The public runners are faster to boot than the custom runners, since GitHub has a slack pool of them. (When comparing test end to end times, bear in mind that GitHub doesn't include the queue time in the reported job time.)

As such, for any use-case that doesn't need a larger number of CPUs, we should use the public runners instead. (Even for CPU bound workloads, the slower boot time often outweighs the benefit of having more CPUs.)

GUS-W-19324156.