### PR TITLE
Add automated check for missing Ruby builds on S3

### DIFF
--- a/.github/workflows/check_new_ruby_releases.yml
+++ b/.github/workflows/check_new_ruby_releases.yml
@@ -1,0 +1,50 @@
+name: Check for new Ruby releases
+run-name: "Check for new Ruby releases"
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # Every 2 hours
+  workflow_dispatch:
+    inputs:
+      dry_run:
+          description: "Print what would be triggered without actually dispatching builds"
+          type: boolean
+          default: false
+          required: false
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  check-releases:
+    runs-on: pub-hk-ubuntu-24.04-xlarge
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Update Rust toolchain
+        run: rustup update
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      - name: Check for missing Ruby versions
+        run: |
+          cargo run --locked --bin ruby_release_check -- \
+            --minimum-version 3.2.0 \
+            --output versions.json \
+            2>"$GITHUB_STEP_SUMMARY"
+      - name: Trigger builds for missing versions
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSIONS=$(jq -r '.[]' versions.json)
+          if [ -z "$VERSIONS" ]; then
+            echo "No versions to build"
+            exit 0
+          fi
+          echo "$VERSIONS" | while IFS= read -r version; do
+            echo "Triggering build for Ruby $version"
+            gh workflow run build_ruby.yml \
+              -f ruby_version="$version" \
+              -f on_conflict=skip
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,10 +1519,14 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yaml",
  "sha2",
  "shared",
  "tar",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -1626,6 +1630,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1732,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1980,7 +2003,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2008,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2032,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -2132,6 +2167,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +491,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,7 +680,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -676,6 +688,18 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
@@ -1521,12 +1545,12 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml",
  "sha2",
  "shared",
  "tar",
  "thiserror 2.0.18",
  "tokio",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -1630,12 +1654,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,19 +1750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2167,12 +2172,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2735,6 +2734,17 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,5 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
 thiserror = "2"
 serde_json = "1"
-serde_yaml = "0.9"
+yaml-rust2 = "0.11"
 toml = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ serde = {version = "1", features = ["derive"] }
 sha2 = "0.10"
 shared = { path = "shared" }
 tar = "0.4"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tempfile = "3"
 thiserror = "2"
+serde_json = "1"
+serde_yaml = "0.9"
 toml = "1.1"

--- a/jruby_executable/src/lib.rs
+++ b/jruby_executable/src/lib.rs
@@ -87,12 +87,34 @@ impl BuildProperties {
     }
 }
 
+const MAX_RETRY_ATTEMPTS: u8 = 3;
+const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+
 pub fn jruby_build_properties(jruby_version: &str) -> Result<BuildProperties, Error> {
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        match jruby_build_properties_inner(jruby_version) {
+            Ok(val) => return Ok(val),
+            Err(error) => {
+                if attempts >= MAX_RETRY_ATTEMPTS {
+                    return Err(error);
+                }
+                std::thread::sleep(RETRY_DELAY);
+            }
+        }
+    }
+}
+
+fn jruby_build_properties_inner(jruby_version: &str) -> Result<BuildProperties, Error> {
     let url = format!(
         "https://raw.githubusercontent.com/jruby/jruby/{jruby_version}/default.build.properties",
     );
 
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(Error::FailedRequest)?;
     let response = client.get(&url).send().map_err(Error::FailedRequest)?;
 
     let body = response

--- a/ruby_executable/Cargo.toml
+++ b/ruby_executable/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = { workspace = true }
 sha2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+yaml-rust2 = { workspace = true }
 shared = { workspace = true }
 tar = { workspace = true }
 thiserror = { workspace = true }

--- a/ruby_executable/Cargo.toml
+++ b/ruby_executable/Cargo.toml
@@ -16,9 +16,13 @@ libherokubuildpack = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 shared = { workspace = true }
 tar = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/ruby_executable/src/bin/ruby_build.rs
+++ b/ruby_executable/src/bin/ruby_build.rs
@@ -5,9 +5,9 @@ use indoc::formatdoc;
 use libherokubuildpack::inventory::artifact::Arch;
 use reqwest::Url;
 use shared::{
-    BaseImage, BuildStatus, RubyDownloadVersion, TarDownloadPath, append_filename_with,
-    download_tar, output_ruby_tar_path, s3_url_exists, sha256_from_path, source_dir,
-    write_job_metadata,
+    BaseImage, BuildStatus, RubyDownloadVersion, S3_BASE_URL, TarDownloadPath,
+    append_filename_with, download_tar, output_ruby_tar_path, s3_url_exists, sha256_from_path,
+    source_dir, write_job_metadata,
 };
 use std::{
     io::Write,
@@ -18,7 +18,6 @@ use std::{
 
 static INNER_OUTPUT: &str = "/tmp/output";
 static INNER_CACHE: &str = "/tmp/cache";
-static S3_BASE_URL: &str = "https://heroku-buildpack-ruby.s3.dualstack.us-east-1.amazonaws.com";
 
 #[derive(clap::ValueEnum, Clone, Debug)]
 enum OnConflict {

--- a/ruby_executable/src/bin/ruby_release_check.rs
+++ b/ruby_executable/src/bin/ruby_release_check.rs
@@ -2,13 +2,13 @@ use bullet_stream::global::print;
 use clap::Parser;
 use fs_err as fs;
 use reqwest::Url;
-use serde::Deserialize;
 use shared::{RubyDownloadVersion, S3_BASE_URL, build_matrix, output_ruby_tar_path};
 use std::{
     error::Error,
     path::{Path, PathBuf},
 };
 use tokio::task::JoinSet;
+use yaml_rust2::YamlLoader;
 
 static RELEASES_URL: std::sync::LazyLock<Url> = std::sync::LazyLock::new(|| {
     Url::parse("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml")
@@ -37,14 +37,16 @@ async fn fetch_releases(url: &Url) -> Result<Vec<RubyDownloadVersion>, Box<dyn s
         .text()
         .await?;
 
-    #[derive(Deserialize)]
-    struct RawEntry {
-        version: String,
-    }
-    let raw: Vec<RawEntry> = serde_yaml::from_str(&body)?;
-    let releases = raw
-        .into_iter()
-        .filter_map(|entry| RubyDownloadVersion::new(&entry.version).ok())
+    let docs = YamlLoader::load_from_str(&body)?;
+    let releases = docs[0]
+        .as_vec()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter_map(|entry| {
+            entry["version"]
+                .as_str()
+                .and_then(|v| RubyDownloadVersion::new(v).ok())
+        })
         .collect();
     Ok(releases)
 }

--- a/ruby_executable/src/bin/ruby_release_check.rs
+++ b/ruby_executable/src/bin/ruby_release_check.rs
@@ -6,14 +6,19 @@ use shared::{RubyDownloadVersion, S3_BASE_URL, build_matrix, output_ruby_tar_pat
 use std::{
     error::Error,
     path::{Path, PathBuf},
+    time::Duration,
 };
 use tokio::task::JoinSet;
+use tokio::time::sleep;
 use yaml_rust2::YamlLoader;
 
 static RELEASES_URL: std::sync::LazyLock<Url> = std::sync::LazyLock::new(|| {
     Url::parse("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml")
         .expect("valid releases URL constant")
 });
+
+const MAX_RETRY_ATTEMPTS: u8 = 3;
+const RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Parser, Debug)]
 #[command(about = "Check for Ruby releases missing from Heroku S3")]
@@ -28,7 +33,27 @@ struct Args {
 }
 
 async fn fetch_releases(url: &Url) -> Result<Vec<RubyDownloadVersion>, Box<dyn std::error::Error>> {
-    let client = reqwest::Client::new();
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        match fetch_releases_inner(url).await {
+            Ok(val) => return Ok(val),
+            Err(error) => {
+                if attempts >= MAX_RETRY_ATTEMPTS {
+                    return Err(error);
+                }
+                sleep(RETRY_DELAY).await;
+            }
+        }
+    }
+}
+
+async fn fetch_releases_inner(
+    url: &Url,
+) -> Result<Vec<RubyDownloadVersion>, Box<dyn std::error::Error>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
     let body = client
         .get(url.clone())
         .send()
@@ -85,7 +110,25 @@ fn urls_to_check(version: &RubyDownloadVersion) -> Vec<(String, Url)> {
 }
 
 async fn s3_url_exists(url: Url) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
-    let client = reqwest::Client::new();
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        match s3_url_exists_inner(url.clone()).await {
+            Ok(val) => return Ok(val),
+            Err(error) => {
+                if attempts >= MAX_RETRY_ATTEMPTS {
+                    return Err(error);
+                }
+                sleep(RETRY_DELAY).await;
+            }
+        }
+    }
+}
+
+async fn s3_url_exists_inner(url: Url) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
     let response = client.head(url.clone()).send().await?;
     match response.status() {
         status if status.is_success() => Ok(true),

--- a/ruby_executable/src/bin/ruby_release_check.rs
+++ b/ruby_executable/src/bin/ruby_release_check.rs
@@ -1,0 +1,246 @@
+use bullet_stream::global::print;
+use clap::Parser;
+use fs_err as fs;
+use reqwest::Url;
+use serde::Deserialize;
+use shared::{RubyDownloadVersion, S3_BASE_URL, build_matrix, output_ruby_tar_path};
+use std::{
+    error::Error,
+    path::{Path, PathBuf},
+};
+use tokio::task::JoinSet;
+
+static RELEASES_URL: std::sync::LazyLock<Url> = std::sync::LazyLock::new(|| {
+    Url::parse("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml")
+        .expect("valid releases URL constant")
+});
+
+#[derive(Parser, Debug)]
+#[command(about = "Check for Ruby releases missing from Heroku S3")]
+struct Args {
+    /// Minimum Ruby version to check (e.g. 3.2.0). All releases >= this version will be checked.
+    #[arg(long = "minimum-version", required = true)]
+    minimum_version: RubyDownloadVersion,
+
+    /// Path to write JSON output file containing versions that need builds
+    #[arg(long = "output", required = true)]
+    output: PathBuf,
+}
+
+async fn fetch_releases(url: &Url) -> Result<Vec<RubyDownloadVersion>, Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let body = client
+        .get(url.clone())
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    #[derive(Deserialize)]
+    struct RawEntry {
+        version: String,
+    }
+    let raw: Vec<RawEntry> = serde_yaml::from_str(&body)?;
+    let releases = raw
+        .into_iter()
+        .filter_map(|entry| RubyDownloadVersion::new(&entry.version).ok())
+        .collect();
+    Ok(releases)
+}
+
+fn version_gte(version: &RubyDownloadVersion, minimum: &RubyDownloadVersion) -> bool {
+    let version_tuple = (version.major, version.minor, version.patch);
+    let minimum_tuple = (minimum.major, minimum.minor, minimum.patch);
+    version_tuple >= minimum_tuple
+}
+
+fn retain_releases_gte(
+    releases: &[RubyDownloadVersion],
+    minimum: &RubyDownloadVersion,
+) -> Vec<RubyDownloadVersion> {
+    releases
+        .iter()
+        .filter(|version| version_gte(version, minimum))
+        .cloned()
+        .collect()
+}
+
+fn urls_to_check(version: &RubyDownloadVersion) -> Vec<(String, Url)> {
+    let matrix = build_matrix();
+    let base_url = Url::parse(S3_BASE_URL).expect("valid base URL constant");
+    matrix
+        .iter()
+        .map(|(base_image, arch)| {
+            let tar_path = output_ruby_tar_path(Path::new(""), version, base_image, Some(arch));
+            let mut url = base_url.clone();
+            url.path_segments_mut()
+                .expect("valid base URL")
+                .extend(tar_path.iter().map(|s| s.to_string_lossy()));
+            (format!("{base_image}/{arch}"), url)
+        })
+        .collect()
+}
+
+async fn s3_url_exists(url: Url) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    let client = reqwest::Client::new();
+    let response = client.head(url.clone()).send().await?;
+    match response.status() {
+        status if status.is_success() => Ok(true),
+        reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::FORBIDDEN => Ok(false),
+        status => Err(format!("Unexpected status {status} checking {url}").into()),
+    }
+}
+
+async fn check_version_on_s3(
+    version: RubyDownloadVersion,
+) -> Result<(RubyDownloadVersion, Vec<String>), Box<dyn std::error::Error + Send + Sync>> {
+    let mut set = JoinSet::new();
+    for (label, url) in urls_to_check(&version) {
+        set.spawn(async move {
+            let exists = s3_url_exists(url).await?;
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>((label, exists))
+        });
+    }
+
+    let mut missing = Vec::new();
+    while let Some(result) = set.join_next().await {
+        let (label, exists) = result??;
+        if !exists {
+            missing.push(label);
+        }
+    }
+
+    Ok((version, missing))
+}
+
+async fn call(args: Args) -> Result<(), Box<dyn Error>> {
+    print::h2("Checking for new Ruby releases");
+    print::bullet(format!("Minimum version: {}", args.minimum_version));
+
+    print::h2(format!("Fetching releases from {}", *RELEASES_URL));
+    let releases = match fetch_releases(&RELEASES_URL).await {
+        Ok(r) => r,
+        Err(e) => {
+            print::error(format!("Failed to fetch releases: {e}"));
+            std::process::exit(1);
+        }
+    };
+    print::bullet(format!("Found {} total releases", releases.len()));
+
+    let versions_to_check = retain_releases_gte(&releases, &args.minimum_version);
+
+    print::bullet(format!(
+        "Checking {} versions on S3",
+        versions_to_check.len()
+    ));
+
+    let mut set = JoinSet::new();
+    for version in versions_to_check {
+        set.spawn(check_version_on_s3(version));
+    }
+
+    let mut versions_to_build = Vec::new();
+    while let Some(result) = set.join_next().await {
+        match result? {
+            Ok((version, missing)) if missing.is_empty() => {
+                print::sub_bullet(format!("{version}: all binaries present"));
+            }
+            Ok((version, missing)) => {
+                print::sub_bullet(format!(
+                    "{version}: missing {} combo(s): {}",
+                    missing.len(),
+                    missing.join(", ")
+                ));
+                versions_to_build.push(version);
+            }
+            Err(e) => {
+                print::warning(format!("Error checking version: {e}"));
+            }
+        }
+    }
+
+    fs::write(
+        &args.output,
+        &serde_json::to_string_pretty(&versions_to_build)?,
+    )?;
+    if versions_to_build.is_empty() {
+        print::bullet("All checked versions are present on S3");
+    } else {
+        print::h2("Versions needing builds");
+        for version in &versions_to_build {
+            print::sub_bullet(format!("{version}"));
+        }
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    match call(args).await {
+        Ok(_) => print::bullet("Done"),
+        Err(e) => {
+            print::error(format!("Failed {e}"));
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_gte() {
+        let min = RubyDownloadVersion::new("3.2.0").unwrap();
+        assert!(version_gte(
+            &RubyDownloadVersion::new("3.2.0").unwrap(),
+            &min
+        ));
+        assert!(version_gte(
+            &RubyDownloadVersion::new("3.3.7").unwrap(),
+            &min
+        ));
+        assert!(version_gte(
+            &RubyDownloadVersion::new("4.0.0").unwrap(),
+            &min
+        ));
+        assert!(!version_gte(
+            &RubyDownloadVersion::new("3.1.9").unwrap(),
+            &min
+        ));
+        assert!(!version_gte(
+            &RubyDownloadVersion::new("2.7.8").unwrap(),
+            &min
+        ));
+    }
+
+    #[test]
+    fn test_version_gte_prerelease() {
+        let min = RubyDownloadVersion::new("3.4.0").unwrap();
+        assert!(version_gte(
+            &RubyDownloadVersion::new("3.4.0-preview1").unwrap(),
+            &min
+        ));
+        assert!(!version_gte(
+            &RubyDownloadVersion::new("3.3.9").unwrap(),
+            &min
+        ));
+    }
+
+    #[test]
+    fn test_retain_releases_gte() {
+        let releases = vec![
+            RubyDownloadVersion::new("3.4.1").unwrap(),
+            RubyDownloadVersion::new("3.3.7").unwrap(),
+            RubyDownloadVersion::new("3.2.0").unwrap(),
+            RubyDownloadVersion::new("3.1.5").unwrap(),
+            RubyDownloadVersion::new("2.7.8").unwrap(),
+        ];
+        let min = RubyDownloadVersion::new("3.2.0").unwrap();
+        let filtered = retain_releases_gte(&releases, &min);
+        let names: Vec<String> = filtered.iter().map(|v| v.to_string()).collect();
+        assert_eq!(names, vec!["3.4.1", "3.3.7", "3.2.0"]);
+    }
+}

--- a/shared/src/base_image.rs
+++ b/shared/src/base_image.rs
@@ -1,3 +1,4 @@
+use libherokubuildpack::inventory::artifact::Arch;
 use std::fmt::Display;
 use std::str::FromStr;
 
@@ -65,4 +66,18 @@ impl FromStr for BaseImage {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         BaseImage::new(s)
     }
+}
+
+/// Returns all valid (BaseImage, Arch) pairs for building Ruby binaries.
+/// heroku-22 supports only amd64; heroku-24 and heroku-26 support amd64 + arm64.
+pub fn build_matrix() -> Vec<(BaseImage, Arch)> {
+    let mut matrix = Vec::new();
+    for &(name, _) in KNOWN_BASE_IMAGES {
+        let base_image = BaseImage::new(name).expect("known base image");
+        matrix.push((base_image.clone(), Arch::Amd64));
+        if name != "heroku-22" {
+            matrix.push((base_image, Arch::Arm64));
+        }
+    }
+    matrix
 }

--- a/shared/src/download_ruby_version.rs
+++ b/shared/src/download_ruby_version.rs
@@ -5,12 +5,27 @@ use winnow::Parser;
 use winnow::ascii::dec_uint;
 use winnow::token::literal;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(into = "String", try_from = "String")]
 pub struct RubyDownloadVersion {
     pub major: u32,
     pub minor: u32,
     pub patch: u32,
     pub rest: String,
+}
+
+impl From<RubyDownloadVersion> for String {
+    fn from(v: RubyDownloadVersion) -> Self {
+        v.to_string()
+    }
+}
+
+impl TryFrom<String> for RubyDownloadVersion {
+    type Error = Error;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        s.parse()
+    }
 }
 
 impl Display for RubyDownloadVersion {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -10,7 +10,7 @@ mod base_image;
 mod download_ruby_version;
 mod inventory_help;
 
-pub use base_image::BaseImage;
+pub use base_image::{BaseImage, build_matrix};
 pub use download_ruby_version::RubyDownloadVersion;
 
 pub static S3_BASE_URL: &str = "https://heroku-buildpack-ruby.s3.dualstack.us-east-1.amazonaws.com";

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,6 +5,29 @@ use reqwest::Url;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
+
+const MAX_RETRY_ATTEMPTS: u8 = 3;
+const RETRY_DELAY: Duration = Duration::from_secs(1);
+
+fn with_retries<T, F>(f: F) -> Result<T, Error>
+where
+    F: Fn() -> Result<T, Error>,
+{
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        match f() {
+            Ok(val) => return Ok(val),
+            Err(error) => {
+                if attempts >= MAX_RETRY_ATTEMPTS {
+                    return Err(error);
+                }
+                std::thread::sleep(RETRY_DELAY);
+            }
+        }
+    }
+}
 
 mod base_image;
 mod download_ruby_version;
@@ -142,7 +165,14 @@ pub fn validate_version_for_stack(
 
 /// Performs an HTTP HEAD request to check if a URL returns a successful status.
 pub fn s3_url_exists(url: Url) -> Result<bool, Error> {
-    let client = reqwest::blocking::Client::new();
+    with_retries(|| s3_url_exists_inner(url.clone()))
+}
+
+fn s3_url_exists_inner(url: Url) -> Result<bool, Error> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(Error::FailedRequest)?;
     let response = client
         .head(url.clone())
         .send()
@@ -157,16 +187,21 @@ pub fn s3_url_exists(url: Url) -> Result<bool, Error> {
 }
 
 pub fn download_tar(url: &str, path: &TarDownloadPath) -> Result<(), Error> {
-    let mut dest = fs::File::create(path.as_ref()).map_err(Error::FsError)?;
+    with_retries(|| download_tar_inner(url, path))
+}
 
-    let client = reqwest::blocking::Client::new();
+fn download_tar_inner(url: &str, path: &TarDownloadPath) -> Result<(), Error> {
+    let mut dest = fs::File::create(path.as_ref()).map_err(Error::FsError)?;
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(300))
+        .build()
+        .map_err(Error::FailedRequest)?;
     let mut response = client.get(url).send().map_err(Error::FailedRequest)?;
     std::io::copy(&mut response, &mut dest).map_err(|err| Error::UrlToFileError {
         url: url.to_string(),
         file: path.as_ref().to_path_buf(),
         source: err,
     })?;
-
     response.error_for_status().map_err(Error::FailedRequest)?;
     Ok(())
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -12,6 +12,8 @@ mod inventory_help;
 
 pub use base_image::BaseImage;
 pub use download_ruby_version::RubyDownloadVersion;
+
+pub static S3_BASE_URL: &str = "https://heroku-buildpack-ruby.s3.dualstack.us-east-1.amazonaws.com";
 pub use inventory_help::{
     ArtifactMetadata, artifact_is_different, artifact_same_url_different_checksum,
     atomic_inventory_update, inventory_check, sha256_from_path,


### PR DESCRIPTION
When new Ruby versions are released on ruby-lang.org, they need to be built for each supported Heroku stack and architecture before customers can use them. Today this is a manual process.

This PR adds a `ruby_release_check` binary and a scheduled GitHub Actions workflow that together automate detection and building of missing Ruby versions:

- `ruby_release_check` fetches the official Ruby release list, filters to versions >= a configurable minimum (currently 3.2.0), and checks S3 HEAD requests in parallel for every stack/arch combination. Missing versions are written to a JSON file.
- The `check_new_ruby_releases.yml` workflow runs every 2 hours (and supports manual dispatch with a `dry_run` option). For each missing version it dispatches the existing `build_ruby.yml` workflow with `on_conflict=skip`.
- Supporting changes extract `S3_BASE_URL` and `build_matrix()` into the shared crate, and add serde support to `RubyDownloadVersion` so versions can be serialized to JSON.