### PR TITLE
Update GH runners

### DIFF
--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   changelog:
-    runs-on: pub-hk-ubuntu-24.04-xlarge
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/build_ruby.yml
+++ b/.github/workflows/build_ruby.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   changelog:
-    runs-on: pub-hk-ubuntu-24.04-xlarge
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/check_new_ruby_releases.yml
+++ b/.github/workflows/check_new_ruby_releases.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   check-releases:
-    runs-on: pub-hk-ubuntu-24.04-xlarge
+    runs-on: pub-hk-ubuntu-24.04-ip # `gh workflow run` needs to be in an IP allow list
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Details in commits:

- Fixes error on https://github.com/heroku/docker-heroku-ruby-builder/actions/runs/24366660558/job/71160077055
- Cheaper/faster `changelog` tasks