### PR TITLE
Fix GHA error

### DIFF
--- a/.github/workflows/check_new_ruby_releases.yml
+++ b/.github/workflows/check_new_ruby_releases.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check for missing Ruby versions
         run: |
           cargo run --locked --bin ruby_release_check -- \
-            --minimum-version 3.2.1 \ # 3.2.0-preview1 and 3.2.0-preview2 do not work on heroku-26
+            --minimum-version 3.2.1 \
             --output versions.json \
             2>"$GITHUB_STEP_SUMMARY"
       - name: Trigger builds for missing versions


### PR DESCRIPTION
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/ruby_release_check --minimum-version 3.2.1 ' #' 3.2.0-preview1 and 3.2.0-preview2 do not work on heroku-26`
error: unexpected argument ' #' found

Usage: ruby_release_check --minimum-version <MINIMUM_VERSION> --output <OUTPUT>

For more information, try '--help'.
```