### PR TITLE
Always create the output directory for jruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           grep -q "Already exists" "$LOGFILE"
           grep -q "skipping" "$LOGFILE"
           grep -q "status=skipped" "$METAFILE"
+          test -d ./output
       - name: "on-conflict=skip: skips when local file exists"
         run: |
           set -euo pipefail
@@ -211,6 +212,7 @@ jobs:
           grep -q "Output already exists locally" "$LOGFILE"
           grep -q "skipping" "$LOGFILE"
           grep -q "status=skipped" "$METAFILE"
+          test -d ./output
 
   check_inventory_urls:
     runs-on: ubuntu-24.04

--- a/jruby_executable/src/bin/jruby_build.rs
+++ b/jruby_executable/src/bin/jruby_build.rs
@@ -57,6 +57,7 @@ fn jruby_build(args: &Args) -> Result<BuildStatus, Box<dyn Error>> {
     let volume_output_dir = source_dir().join("output");
 
     fs::create_dir_all(&volume_cache_dir)?;
+    fs::create_dir_all(&volume_output_dir)?;
 
     let ruby_stdlib_version = jruby_build_properties(version)?.ruby_stdlib_version()?;
     let tgz_name = format!("ruby-{ruby_stdlib_version}-jruby-{version}.tgz");


### PR DESCRIPTION
Previously when the build was skipped, the S3 check would still run, but it fails because the directory is not created. This change always creates the output directory.

close #138