### PR TITLE
Explicit directories

### DIFF
--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -66,6 +66,8 @@ jobs:
             --version ${{inputs.jruby_version}} \
             --base-image ${{matrix.base_image}} \
             --on-conflict ${{inputs.on_conflict}} \
+            --artifact-dir ./output \
+            --cache-dir ./cache \
             --job-metadata "$GITHUB_OUTPUT"
       - name: Check JRuby
         if: steps.build.outputs.status == 'success'
@@ -74,6 +76,7 @@ jobs:
             --version ${{inputs.jruby_version}} \
             --base-image ${{matrix.base_image}} \
             --arch amd64 \
+            --artifact-dir ./output \
             | tee $GITHUB_STEP_SUMMARY
       - name: Upload JRuby runtime archive to S3 dry run
         if: ${{ inputs.dry_run }}

--- a/.github/workflows/build_ruby.yml
+++ b/.github/workflows/build_ruby.yml
@@ -71,6 +71,8 @@ jobs:
             --base-image ${{matrix.base_image}} \
             --arch ${{matrix.arch}} \
             --on-conflict ${{inputs.on_conflict}} \
+            --artifact-dir ./output \
+            --cache-dir ./cache \
             --job-metadata "$GITHUB_OUTPUT"
       - name: Check Ruby
         if: steps.build.outputs.status == 'success'
@@ -79,6 +81,7 @@ jobs:
             --version ${{inputs.ruby_version}} \
             --base-image ${{matrix.base_image}} \
             --arch ${{matrix.arch}} \
+            --artifact-dir ./output \
             | tee $GITHUB_STEP_SUMMARY
       - name: Upload Ruby runtime archive to S3 dry run
         if: ${{ inputs.dry_run }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
             --base-image ${{matrix.base_image}} \
             --arch ${{matrix.arch}} \
             --on-conflict overwrite \
+            --artifact-dir ./output \
+            --cache-dir ./cache \
             --job-metadata "$METAFILE"
           grep -q "status=success" "$METAFILE"
       - name: Check Ruby
@@ -83,7 +85,8 @@ jobs:
           cargo run --locked --bin ruby_check -- \
             --version ${{matrix.version}} \
             --base-image ${{matrix.base_image}} \
-            --arch ${{matrix.arch}}
+            --arch ${{matrix.arch}} \
+            --artifact-dir ./output
       - name: Verify output paths
         run: |
           set -euo pipefail
@@ -121,6 +124,8 @@ jobs:
             --version ${{matrix.version}} \
             --base-image ${{matrix.base_image}} \
             --on-conflict overwrite \
+            --artifact-dir ./output \
+            --cache-dir ./cache \
             --job-metadata "$METAFILE"
           grep -q "status=success" "$METAFILE"
       - name: Check JRuby
@@ -128,7 +133,8 @@ jobs:
           cargo run --locked --bin jruby_check -- \
             --version ${{matrix.version}} \
             --base-image ${{matrix.base_image}} \
-            --arch ${{matrix.arch}}
+            --arch ${{matrix.arch}} \
+            --artifact-dir ./output
 
   ruby_on_conflict_test:
     runs-on: ubuntu-24.04
@@ -151,6 +157,8 @@ jobs:
             --base-image heroku-24 \
             --arch amd64 \
             --on-conflict skip \
+            --artifact-dir ./output \
+            --cache-dir ./cache \
             --job-metadata "$METAFILE" 2>&1 | tee "$LOGFILE"
           grep -q "Already exists" "$LOGFILE"
           grep -q "skipping" "$LOGFILE"
@@ -167,6 +175,8 @@ jobs:
             --base-image heroku-24 \
             --arch amd64 \
             --on-conflict skip \
+            --artifact-dir ./output \
+            --cache-dir ./cache \
             --job-metadata "$METAFILE" 2>&1 | tee "$LOGFILE"
           grep -q "Output already exists locally" "$LOGFILE"
           grep -q "skipping" "$LOGFILE"
@@ -192,6 +202,8 @@ jobs:
             --version 9.4.7.0 \
             --base-image heroku-22 \
             --on-conflict skip \
+            --artifact-dir ./output \
+            --cache-dir ./cache \
             --job-metadata "$METAFILE" 2>&1 | tee "$LOGFILE"
           grep -q "Already exists" "$LOGFILE"
           grep -q "skipping" "$LOGFILE"
@@ -208,6 +220,8 @@ jobs:
             --version 9.4.7.0 \
             --base-image heroku-22 \
             --on-conflict skip \
+            --artifact-dir ./output \
+            --cache-dir ./cache \
             --job-metadata "$METAFILE" 2>&1 | tee "$LOGFILE"
           grep -q "Output already exists locally" "$LOGFILE"
           grep -q "skipping" "$LOGFILE"

--- a/jruby_executable/src/bin/jruby_build.rs
+++ b/jruby_executable/src/bin/jruby_build.rs
@@ -38,6 +38,12 @@ struct Args {
     #[arg(long)]
     on_conflict: OnConflict,
 
+    #[arg(long = "artifact-dir")]
+    artifact_dir: PathBuf,
+
+    #[arg(long = "cache-dir")]
+    cache_dir: PathBuf,
+
     #[arg(long = "job-metadata")]
     job_metadata: Option<PathBuf>,
 }
@@ -47,17 +53,19 @@ fn jruby_build(args: &Args) -> Result<BuildStatus, Box<dyn Error>> {
         version,
         base_image,
         on_conflict,
+        artifact_dir,
+        cache_dir,
         job_metadata: _,
     } = args;
 
     let start = Instant::now();
     print::h2("Building JRuby");
     let inventory = source_dir().join("jruby_inventory.toml");
-    let volume_cache_dir = source_dir().join("cache");
-    let volume_output_dir = source_dir().join("output");
+    let volume_cache_dir = cache_dir;
+    let volume_output_dir = artifact_dir;
 
-    fs::create_dir_all(&volume_cache_dir)?;
-    fs::create_dir_all(&volume_output_dir)?;
+    fs::create_dir_all(volume_cache_dir)?;
+    fs::create_dir_all(volume_output_dir)?;
 
     let ruby_stdlib_version = jruby_build_properties(version)?.ruby_stdlib_version()?;
     let tgz_name = format!("ruby-{ruby_stdlib_version}-jruby-{version}.tgz");
@@ -75,7 +83,7 @@ fn jruby_build(args: &Args) -> Result<BuildStatus, Box<dyn Error>> {
                 return Ok(BuildStatus::Skipped);
             }
 
-            let s3_path = expected_output.strip_prefix(&volume_output_dir)?;
+            let s3_path = expected_output.strip_prefix(volume_output_dir)?;
             let url = {
                 let mut url = Url::parse(S3_BASE_URL)?;
                 url.path_segments_mut()
@@ -178,7 +186,7 @@ fn jruby_build(args: &Args) -> Result<BuildStatus, Box<dyn Error>> {
             arch: cpu_arch,
             url: format!(
                 "{S3_BASE_URL}/{}",
-                sha_seven_path.strip_prefix(&volume_output_dir)?.display()
+                sha_seven_path.strip_prefix(volume_output_dir)?.display()
             ),
             checksum: format!("sha256:{sha}").parse()?,
             metadata: ArtifactMetadata {

--- a/jruby_executable/src/bin/jruby_check.rs
+++ b/jruby_executable/src/bin/jruby_check.rs
@@ -21,6 +21,9 @@ struct RubyArgs {
 
     #[arg(long = "base-image")]
     base_image: BaseImage,
+
+    #[arg(long = "artifact-dir")]
+    artifact_dir: PathBuf,
 }
 
 fn jruby_check(args: &RubyArgs) -> Result<(), Box<dyn Error>> {
@@ -28,6 +31,7 @@ fn jruby_check(args: &RubyArgs) -> Result<(), Box<dyn Error>> {
         arch,
         version,
         base_image,
+        artifact_dir,
     } = args;
 
     let jruby_stdlib_version = jruby_build_properties(version)?.ruby_stdlib_version()?;
@@ -52,7 +56,7 @@ fn jruby_check(args: &RubyArgs) -> Result<(), Box<dyn Error>> {
         write!(stream, "{}", dockerfile_path.display())
     })?;
 
-    let outside_output = source_dir().join("output");
+    let outside_output = artifact_dir;
 
     print::bullet(format!("Docker image {image_name}"));
     let mut docker_build = Command::new("docker");

--- a/ruby_executable/src/bin/ruby_build.rs
+++ b/ruby_executable/src/bin/ruby_build.rs
@@ -39,6 +39,12 @@ struct RubyArgs {
     #[arg(long)]
     on_conflict: OnConflict,
 
+    #[arg(long = "artifact-dir")]
+    artifact_dir: PathBuf,
+
+    #[arg(long = "cache-dir")]
+    cache_dir: PathBuf,
+
     #[arg(long = "job-metadata")]
     job_metadata: Option<PathBuf>,
 }
@@ -56,18 +62,20 @@ fn ruby_build(args: &RubyArgs) -> Result<BuildStatus, Box<dyn std::error::Error>
         version,
         base_image,
         on_conflict,
+        artifact_dir,
+        cache_dir,
         job_metadata: _,
     } = args;
 
     let start = Instant::now();
     print::h2("Building Ruby");
-    let volume_cache_dir = source_dir().join("cache");
-    let volume_output_dir = source_dir().join("output");
+    let volume_cache_dir = cache_dir;
+    let volume_output_dir = artifact_dir;
 
-    fs::create_dir_all(&volume_cache_dir)?;
-    fs::create_dir_all(&volume_output_dir)?;
+    fs::create_dir_all(volume_cache_dir)?;
+    fs::create_dir_all(volume_output_dir)?;
 
-    let expected_output = output_ruby_tar_path(&volume_output_dir, version, base_image, Some(arch));
+    let expected_output = output_ruby_tar_path(volume_output_dir, version, base_image, Some(arch));
 
     match on_conflict {
         OnConflict::Skip => {
@@ -79,7 +87,7 @@ fn ruby_build(args: &RubyArgs) -> Result<BuildStatus, Box<dyn std::error::Error>
                 return Ok(BuildStatus::Skipped);
             }
 
-            let s3_path = expected_output.strip_prefix(&volume_output_dir)?;
+            let s3_path = expected_output.strip_prefix(volume_output_dir)?;
             let url = {
                 let mut url = Url::parse(S3_BASE_URL)?;
                 url.path_segments_mut()
@@ -156,14 +164,14 @@ fn ruby_build(args: &RubyArgs) -> Result<BuildStatus, Box<dyn std::error::Error>
 
     print::sub_stream_cmd(docker_run)?;
 
-    let output_tar = output_ruby_tar_path(&volume_output_dir, version, base_image, Some(arch));
+    let output_tar = output_ruby_tar_path(volume_output_dir, version, base_image, Some(arch));
 
     let sha_seven_path = cp_file_sha_seven_same_dir(&output_tar)?;
 
     print::sub_bullet(format!("Copied SHA tgz {}", sha_seven_path.display(),));
 
     if base_image.has_legacy_path() {
-        let legacy_output = output_ruby_tar_path(&volume_output_dir, version, base_image, None);
+        let legacy_output = output_ruby_tar_path(volume_output_dir, version, base_image, None);
         fs::copy(expected_output, &legacy_output)?;
         cp_file_sha_seven_same_dir(&legacy_output)?;
     }

--- a/ruby_executable/src/bin/ruby_check.rs
+++ b/ruby_executable/src/bin/ruby_check.rs
@@ -2,7 +2,7 @@ use bullet_stream::global::print;
 use clap::Parser;
 use indoc::formatdoc;
 use libherokubuildpack::inventory::artifact::Arch;
-use shared::{BaseImage, RubyDownloadVersion, output_ruby_tar_path, source_dir};
+use shared::{BaseImage, RubyDownloadVersion, output_ruby_tar_path};
 use std::{error::Error, path::PathBuf, process::Command, time::Instant};
 
 static INNER_OUTPUT: &str = "/tmp/output";
@@ -17,6 +17,9 @@ struct RubyArgs {
 
     #[arg(long = "base-image")]
     base_image: BaseImage,
+
+    #[arg(long = "artifact-dir")]
+    artifact_dir: PathBuf,
 }
 
 fn ruby_check(args: &RubyArgs) -> Result<(), Box<dyn Error>> {
@@ -24,6 +27,7 @@ fn ruby_check(args: &RubyArgs) -> Result<(), Box<dyn Error>> {
         arch,
         version,
         base_image,
+        artifact_dir,
     } = args;
     let start = Instant::now();
     print::h2(format!(
@@ -38,7 +42,7 @@ fn ruby_check(args: &RubyArgs) -> Result<(), Box<dyn Error>> {
     let distro_number = base_image.distro_number();
 
     let image_name = format!("heroku/heroku:{distro_number}-build");
-    let outside_output = source_dir().join("output");
+    let outside_output = artifact_dir;
 
     let mut cmd = Command::new("docker");
     cmd.arg("run");


### PR DESCRIPTION
Previously, the clis implicitly used ./output and ./cache in the CARGO_MANIFEST_DIR directory. It's not intuitively obvious when looking at the command invocations. By injecting the directories, it is more explicit and clearer.