### PR TITLE
Skip S3 upload when build is skipped

### DIFF
--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -78,12 +78,8 @@ jobs:
             --arch amd64 \
             --artifact-dir ./output \
             | tee $GITHUB_STEP_SUMMARY
-      - name: Upload JRuby runtime archive to S3 dry run
-        if: ${{ inputs.dry_run }}
-        run: aws s3 sync ./output "s3://${S3_BUCKET}" --dryrun
-      - name: Upload JRuby runtime archive to S3 production
-        if: ${{ !inputs.dry_run }}
-        run: aws s3 sync ./output "s3://${S3_BUCKET}"
+      - name: Upload JRuby runtime archive to S3
+        run: aws s3 sync ./output "s3://${S3_BUCKET}" ${{ case(inputs.dry_run, '--dryrun', '') }}
 
   # # TODO: Pass data from prior jobs to generate one single inventory file
   # #       before generating a PR.

--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -79,6 +79,7 @@ jobs:
             --artifact-dir ./output \
             | tee $GITHUB_STEP_SUMMARY
       - name: Upload JRuby runtime archive to S3
+        if: steps.build.outputs.status == 'success'
         run: aws s3 sync ./output "s3://${S3_BUCKET}" ${{ case(inputs.dry_run, '--dryrun', '') }}
 
   # # TODO: Pass data from prior jobs to generate one single inventory file

--- a/.github/workflows/build_ruby.yml
+++ b/.github/workflows/build_ruby.yml
@@ -83,9 +83,5 @@ jobs:
             --arch ${{matrix.arch}} \
             --artifact-dir ./output \
             | tee $GITHUB_STEP_SUMMARY
-      - name: Upload Ruby runtime archive to S3 dry run
-        if: ${{ inputs.dry_run }}
-        run: aws s3 sync ./output "s3://${S3_BUCKET}" --dryrun
-      - name: Upload Ruby runtime archive to S3 production
-        if: ${{ !inputs.dry_run }}
-        run: aws s3 sync ./output "s3://${S3_BUCKET}"
+      - name: Upload Ruby runtime archive to S3
+        run: aws s3 sync ./output "s3://${S3_BUCKET}" ${{ case(inputs.dry_run, '--dryrun', '') }}

--- a/.github/workflows/build_ruby.yml
+++ b/.github/workflows/build_ruby.yml
@@ -84,4 +84,5 @@ jobs:
             --artifact-dir ./output \
             | tee $GITHUB_STEP_SUMMARY
       - name: Upload Ruby runtime archive to S3
+        if: steps.build.outputs.status == 'success'
         run: aws s3 sync ./output "s3://${S3_BUCKET}" ${{ case(inputs.dry_run, '--dryrun', '') }}


### PR DESCRIPTION


For example, in https://github.com/heroku/docker-heroku-ruby-builder/actions/runs/24792645690
the build detected the artifact already existed and skipped:

    - Already exists: .../heroku-24/ruby-4.0.0-jruby-10.1.0.0.tgz, skipping

Then the unconditional upload step failed:

    aws: [ERROR]: The user-provided path ./output does not exist.

When `--on-conflict skip` causes the build to be skipped, no `./output`
directory is created. Guard the upload step with the same
`status == 'success'` check already used by the "Check" steps.