### PR TITLE
Clean up changelog output for copy-paste into devcenter

### DIFF
--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
             set -euo pipefail
             {
+              # 4 backticks so the inner ```ruby fences in the changelog render literally
               echo '````'
               cargo run --locked --bin jruby_changelog -- --version "${{inputs.jruby_version}}"
               echo '````'

--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -44,7 +44,13 @@ jobs:
       - name: Cargo build
         run: cargo build --locked
       - name: Output CHANGELOG
-        run: cargo run --locked --bin jruby_changelog -- --version "${{inputs.jruby_version}}" | tee "$GITHUB_STEP_SUMMARY"
+        run: |
+            set -euo pipefail
+            {
+              echo '````'
+              cargo run --locked --bin jruby_changelog -- --version "${{inputs.jruby_version}}"
+              echo '````'
+            } | tee -a "$GITHUB_STEP_SUMMARY"
 
   build-and-upload:
     runs-on: pub-hk-ubuntu-24.04-xlarge

--- a/.github/workflows/build_jruby.yml
+++ b/.github/workflows/build_jruby.yml
@@ -41,6 +41,8 @@ jobs:
         run: rustup update
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Cargo build
+        run: cargo build --locked
       - name: Output CHANGELOG
         run: cargo run --locked --bin jruby_changelog -- --version "${{inputs.jruby_version}}" | tee "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/build_ruby.yml
+++ b/.github/workflows/build_ruby.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
             set -euo pipefail
             {
+              # 4 backticks so the inner ```ruby fences in the changelog render literally
               echo '````'
               cargo run --locked --bin ruby_changelog -- --version "${{inputs.ruby_version}}"
               echo '````'

--- a/.github/workflows/build_ruby.yml
+++ b/.github/workflows/build_ruby.yml
@@ -41,6 +41,8 @@ jobs:
         run: rustup update
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Cargo build
+        run: cargo build --locked
       - name: Output CHANGELOG
         run: cargo run --locked --bin ruby_changelog -- --version "${{inputs.ruby_version}}" | tee "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/build_ruby.yml
+++ b/.github/workflows/build_ruby.yml
@@ -44,7 +44,13 @@ jobs:
       - name: Cargo build
         run: cargo build --locked
       - name: Output CHANGELOG
-        run: cargo run --locked --bin ruby_changelog -- --version "${{inputs.ruby_version}}" | tee "$GITHUB_STEP_SUMMARY"
+        run: |
+            set -euo pipefail
+            {
+              echo '````'
+              cargo run --locked --bin ruby_changelog -- --version "${{inputs.ruby_version}}"
+              echo '````'
+            } | tee -a "$GITHUB_STEP_SUMMARY"
 
   build-and-upload:
     runs-on: ${{ matrix.arch == 'arm64' && 'pub-hk-ubuntu-24.04-arm-xlarge' || 'pub-hk-ubuntu-24.04-xlarge' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ dependencies = [
  "java-properties",
  "lazy_static",
  "libherokubuildpack",
+ "pretty_assertions",
  "regex",
  "reqwest",
  "serde",

--- a/jruby_executable/Cargo.toml
+++ b/jruby_executable/Cargo.toml
@@ -38,3 +38,6 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 winnow = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/jruby_executable/src/bin/jruby_changelog.rs
+++ b/jruby_executable/src/bin/jruby_changelog.rs
@@ -16,9 +16,6 @@ fn jruby_changelog(args: &Args) -> Result<(), Box<dyn Error>> {
 
     let stdlib_version = jruby_build_properties(version)?.ruby_stdlib_version()?;
 
-    println!("Add a changelog item: https://devcenter.heroku.com/admin/changelog_items/new");
-    println!();
-
     let changelog = formatdoc! {"
         ## JRuby version {version} is now available
 

--- a/jruby_executable/src/bin/jruby_changelog.rs
+++ b/jruby_executable/src/bin/jruby_changelog.rs
@@ -1,4 +1,4 @@
-use std::error::Error;
+use std::{error::Error, io::Write};
 
 use bullet_stream::global::print;
 use clap::Parser;
@@ -11,7 +11,10 @@ struct Args {
     version: JRubyVersion,
 }
 
-fn jruby_changelog(args: &Args) -> Result<(), Box<dyn Error>> {
+fn jruby_changelog<W>(args: &Args, mut io: W) -> Result<W, Box<dyn Error>>
+where
+    W: Write,
+{
     let Args { version } = args;
 
     let stdlib_version = jruby_build_properties(version)?.ruby_stdlib_version()?;
@@ -29,14 +32,14 @@ fn jruby_changelog(args: &Args) -> Result<(), Box<dyn Error>> {
         The JRuby release notes can be found on the [JRuby website](https://www.jruby.org/news).
     "};
 
-    print::plain(changelog);
+    writeln!(io, "{changelog}")?;
 
-    Ok(())
+    Ok(io)
 }
 
 fn main() {
     let args = Args::parse();
-    if let Err(error) = jruby_changelog(&args) {
+    if let Err(error) = jruby_changelog(&args, std::io::stdout()) {
         print::error(formatdoc! {"
             ❌ Command failed ❌
 

--- a/jruby_executable/src/bin/jruby_changelog.rs
+++ b/jruby_executable/src/bin/jruby_changelog.rs
@@ -23,7 +23,7 @@ where
 }
 
 fn render_jruby_changelog<W>(
-    version: &str,
+    version: &JRubyVersion,
     stdlib_version: &str,
     mut io: W,
 ) -> Result<W, Box<dyn Error>>
@@ -70,7 +70,9 @@ mod test {
     fn regular_release() {
         let mut io = Vec::new();
 
-        let output = render_jruby_changelog("9.4.7.0", "3.1.4", &mut io).unwrap();
+        let output =
+            render_jruby_changelog(&JRubyVersion::parse("9.4.7.0").unwrap(), "3.1.4", &mut io)
+                .unwrap();
         let actual = String::from_utf8_lossy(output);
         let expected = formatdoc! {"
                 ## JRuby version 9.4.7.0 is now available

--- a/jruby_executable/src/bin/jruby_changelog.rs
+++ b/jruby_executable/src/bin/jruby_changelog.rs
@@ -11,7 +11,7 @@ struct Args {
     version: JRubyVersion,
 }
 
-fn jruby_changelog<W>(args: &Args, mut io: W) -> Result<W, Box<dyn Error>>
+fn jruby_changelog<W>(args: &Args, io: W) -> Result<W, Box<dyn Error>>
 where
     W: Write,
 {
@@ -19,6 +19,17 @@ where
 
     let stdlib_version = jruby_build_properties(version)?.ruby_stdlib_version()?;
 
+    render_jruby_changelog(version, &stdlib_version, io)
+}
+
+fn render_jruby_changelog<W>(
+    version: &str,
+    stdlib_version: &str,
+    mut io: W,
+) -> Result<W, Box<dyn Error>>
+where
+    W: Write,
+{
     let changelog = formatdoc! {"
         ## JRuby version {version} is now available
 
@@ -47,5 +58,32 @@ fn main() {
         "});
 
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn regular_release() {
+        let mut io = Vec::new();
+
+        let output = render_jruby_changelog("9.4.7.0", "3.1.4", &mut io).unwrap();
+        let actual = String::from_utf8_lossy(output);
+        let expected = formatdoc! {"
+                ## JRuby version 9.4.7.0 is now available
+
+                [JRuby v9.4.7.0](/articles/ruby-support-reference#supported-jruby-versions) is now available on Heroku. To run
+                your app using this version of Ruby, add the following `ruby` directive to your Gemfile:
+
+                ```ruby
+                ruby \"3.1.4\", engine: \"jruby\", engine_version: \"9.4.7.0\"
+                ```
+
+                The JRuby release notes can be found on the [JRuby website](https://www.jruby.org/news).
+            "};
+        assert_eq!(expected.trim(), actual.trim());
     }
 }

--- a/ruby_executable/src/bin/ruby_changelog.rs
+++ b/ruby_executable/src/bin/ruby_changelog.rs
@@ -17,13 +17,6 @@ where
 {
     let Args { version } = args;
 
-    writeln!(
-        io,
-        "Add a changelog item: https://devcenter.heroku.com/admin/changelog_items/new"
-    )?;
-
-    writeln!(io)?;
-
     let gemfile_format = version.bundler_format();
 
     let changelog = formatdoc! {"
@@ -81,8 +74,6 @@ mod test {
         let output = ruby_changelog(&args, &mut io).unwrap();
         let actual = String::from_utf8_lossy(output);
         let expected = formatdoc! {"
-                Add a changelog item: https://devcenter.heroku.com/admin/changelog_items/new
-
                 ## Ruby version 3.3.2 is now available
 
                 [Ruby v3.3.2](/articles/ruby-support#ruby-versions) is now available on Heroku. To run \
@@ -106,8 +97,6 @@ mod test {
         let output = ruby_changelog(&args, &mut io).unwrap();
         let actual = String::from_utf8_lossy(output);
         let expected = formatdoc! {"
-                Add a changelog item: https://devcenter.heroku.com/admin/changelog_items/new
-
                 ## Ruby version 3.1.0-rc1 is now available
 
                 [Ruby v3.1.0-rc1](/articles/ruby-support#ruby-versions) is now available on Heroku. To run \


### PR DESCRIPTION
Cleans up the changelog printing for binary build steps. Details in commits.