### PR TITLE
Speedup tests

### DIFF
--- a/ruby_executable/src/bin/ruby_release_check.rs
+++ b/ruby_executable/src/bin/ruby_release_check.rs
@@ -18,7 +18,11 @@ static RELEASES_URL: std::sync::LazyLock<Url> = std::sync::LazyLock::new(|| {
 });
 
 const MAX_RETRY_ATTEMPTS: u8 = 3;
-const RETRY_DELAY: Duration = Duration::from_secs(1);
+#[cfg(not(test))]
+pub const RETRY_DELAY: Duration = Duration::from_secs(1);
+// Avoid real sleeps in unit tests; retry logic is still exercised, just without wall-clock delay.
+#[cfg(test)]
+pub const RETRY_DELAY: Duration = Duration::from_millis(0);
 
 #[derive(Parser, Debug)]
 #[command(about = "Check for Ruby releases missing from Heroku S3")]

--- a/shared/src/inventory_help.rs
+++ b/shared/src/inventory_help.rs
@@ -20,7 +20,7 @@ pub struct ArtifactMetadata {
     pub distro_version: DistroVersion,
 }
 
-/// ```
+/// ```no_run
 /// use shared::inventory_check;
 ///
 /// let contents = r#"

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -8,7 +8,11 @@ use std::process::Command;
 use std::time::Duration;
 
 pub const MAX_RETRY_ATTEMPTS: u8 = 3;
+#[cfg(not(test))]
 pub const RETRY_DELAY: Duration = Duration::from_secs(1);
+// Avoid real sleeps in unit tests; retry logic is still exercised, just without wall-clock delay.
+#[cfg(test)]
+pub const RETRY_DELAY: Duration = Duration::from_millis(0);
 
 pub fn with_retries<T, E, F>(f: F) -> Result<T, E>
 where


### PR DESCRIPTION
Before:

```
$ cargo build && time cargo test 
cargo test  4.95s user 3.16s system 45% cpu 17.640 total
```

After:

```
$ cargo build && time cargo test 
cargo test 0.58s user 0.36s system 75% cpu 1.243 total
```