### PR TITLE
Refactor Error accumulation with `Vec<Result<T,E>>`

### DIFF
--- a/ruby_executable/src/bin/ruby_release_check.rs
+++ b/ruby_executable/src/bin/ruby_release_check.rs
@@ -2,7 +2,7 @@ use bullet_stream::global::print;
 use clap::Parser;
 use fs_err as fs;
 use reqwest::{Client, Url};
-use shared::maybe_err::{MaybeErrors, NonEmptyErrors, OkMaybe};
+use shared::maybe_err::ResultIterExt;
 use shared::{RubyDownloadVersion, S3_BASE_URL, build_matrix, output_ruby_tar_path, s3_url_exists};
 use std::{
     error::Error,
@@ -82,31 +82,21 @@ fn parse_flat_yaml(body: String) -> Result<Vec<Yaml>, FlatYamlError> {
 /// Parses output from Ruby Lang into Ruby Versions
 ///
 /// Fault tolerant parse result of <https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml>
-fn ruby_lang_versions(
-    body: String,
-) -> OkMaybe<Vec<RubyDownloadVersion>, NonEmptyErrors<RubyLangEntryError>> {
-    let mut errors = MaybeErrors::new();
-    let mut releases = Vec::new();
-
+fn ruby_lang_versions(body: String) -> Vec<Result<RubyDownloadVersion, RubyLangEntryError>> {
     match parse_flat_yaml(body) {
-        Ok(entries) => {
-            for entry in entries {
-                match entry["version"]
+        Ok(entries) => entries
+            .into_iter()
+            .map(|entry| {
+                entry["version"]
                     .as_str()
                     .ok_or_else(|| RubyLangEntryError::MissingVersion(entry.clone()))
                     .and_then(|v| {
                         RubyDownloadVersion::new(v).map_err(RubyLangEntryError::CannotParse)
-                    }) {
-                    Ok(v) => releases.push(v),
-                    Err(error) => errors.push(error),
-                }
-            }
-        }
-        Err(error) => {
-            errors.push(error.into());
-        }
+                    })
+            })
+            .collect(),
+        Err(error) => vec![Err(error.into())],
     }
-    errors.ok_maybe(releases)
 }
 
 fn version_gte(version: &RubyDownloadVersion, minimum: &RubyDownloadVersion) -> bool {
@@ -164,15 +154,16 @@ async fn check_version_on_s3(
     Ok((version, missing))
 }
 
-async fn call(args: Args) -> OkMaybe<(), NonEmptyErrors<Box<dyn Error>>> {
+async fn call(args: Args) -> Vec<Result<(), Box<dyn Error>>> {
     print::h2("Checking for new Ruby releases");
     print::bullet(format!("Minimum version: {}", args.minimum_version));
 
-    let mut errors: MaybeErrors<Box<dyn Error>> = MaybeErrors::new();
-
+    let mut errors: Vec<Box<dyn Error>> = Vec::new();
     print::h2(format!("Fetching releases from {}", *RELEASES_URL));
     let releases = match fetch_ruby_lang_body(&RELEASES_URL).await {
-        Ok(body) => ruby_lang_versions(body).drain_unwrap(&mut errors),
+        Ok(body) => ruby_lang_versions(body)
+            .into_iter()
+            .unwrap_drain(&mut errors),
         Err(e) => {
             errors.push(e.into());
             Vec::new()
@@ -226,18 +217,28 @@ async fn call(args: Args) -> OkMaybe<(), NonEmptyErrors<Box<dyn Error>>> {
             print::sub_bullet(format!("{version}"));
         }
     }
-    errors.ok_maybe(())
+    errors.into_iter().map(Result::Err).collect()
 }
 
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
-    match call(args).await {
-        OkMaybe(_, None) => print::bullet("Done"),
-        OkMaybe(_, Some(errors)) => {
-            print::error(format!("Failed {errors}"));
-            std::process::exit(1);
-        }
+    let errors: Vec<_> = call(args)
+        .await
+        .into_iter()
+        .filter_map(Result::err)
+        .collect();
+
+    if errors.is_empty() {
+        print::bullet("done");
+    } else {
+        let errors = errors
+            .into_iter()
+            .map(|error| format!("- {error}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        print::error(format!("Failed\n\n{errors}"));
+        std::process::exit(1);
     }
 }
 
@@ -254,14 +255,10 @@ mod tests {
         "}
         .to_string();
 
-        let mut errors = MaybeErrors::<RubyLangEntryError>::new();
+        let (versions, errors) = ruby_lang_versions(body).partition_result_vec();
         assert_eq!(
             vec![String::from("4.0.5")],
-            ruby_lang_versions(body)
-                .drain_unwrap(&mut errors)
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<_>>()
+            versions.iter().map(|v| v.to_string()).collect::<Vec<_>>()
         );
 
         assert_eq!(1, errors.len());
@@ -291,14 +288,10 @@ mod tests {
         "}
         .to_string();
 
-        let mut errors = MaybeErrors::<RubyLangEntryError>::new();
+        let (versions, errors) = ruby_lang_versions(body).partition_result_vec();
         assert_eq!(
             vec![String::from("4.0.5")],
-            ruby_lang_versions(body)
-                .drain_unwrap(&mut errors)
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<_>>()
+            versions.iter().map(|v| v.to_string()).collect::<Vec<_>>()
         );
 
         assert_eq!(1, errors.len());

--- a/ruby_executable/src/bin/ruby_release_check.rs
+++ b/ruby_executable/src/bin/ruby_release_check.rs
@@ -2,7 +2,7 @@ use bullet_stream::global::print;
 use clap::Parser;
 use fs_err as fs;
 use reqwest::{Client, Url};
-use shared::maybe_err::ResultIterExt;
+use shared::maybe_err::ResultVec;
 use shared::{RubyDownloadVersion, S3_BASE_URL, build_matrix, output_ruby_tar_path, s3_url_exists};
 use std::{
     error::Error,
@@ -82,7 +82,7 @@ fn parse_flat_yaml(body: String) -> Result<Vec<Yaml>, FlatYamlError> {
 /// Parses output from Ruby Lang into Ruby Versions
 ///
 /// Fault tolerant parse result of <https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml>
-fn ruby_lang_versions(body: String) -> Vec<Result<RubyDownloadVersion, RubyLangEntryError>> {
+fn ruby_lang_versions(body: String) -> ResultVec<RubyDownloadVersion, RubyLangEntryError> {
     match parse_flat_yaml(body) {
         Ok(entries) => entries
             .into_iter()
@@ -97,6 +97,7 @@ fn ruby_lang_versions(body: String) -> Vec<Result<RubyDownloadVersion, RubyLangE
             .collect(),
         Err(error) => vec![Err(error.into())],
     }
+    .into()
 }
 
 fn version_gte(version: &RubyDownloadVersion, minimum: &RubyDownloadVersion) -> bool {
@@ -154,16 +155,14 @@ async fn check_version_on_s3(
     Ok((version, missing))
 }
 
-async fn call(args: Args) -> Vec<Result<(), Box<dyn Error>>> {
+async fn call(args: Args) -> ResultVec<(), Box<dyn Error>> {
     print::h2("Checking for new Ruby releases");
     print::bullet(format!("Minimum version: {}", args.minimum_version));
 
     let mut errors: Vec<Box<dyn Error>> = Vec::new();
     print::h2(format!("Fetching releases from {}", *RELEASES_URL));
     let releases = match fetch_ruby_lang_body(&RELEASES_URL).await {
-        Ok(body) => ruby_lang_versions(body)
-            .into_iter()
-            .unwrap_drain(&mut errors),
+        Ok(body) => ruby_lang_versions(body).unwrap_drain_errs(&mut errors),
         Err(e) => {
             errors.push(e.into());
             Vec::new()
@@ -255,7 +254,8 @@ mod tests {
         "}
         .to_string();
 
-        let (versions, errors) = ruby_lang_versions(body).partition_result_vec();
+        let mut errors = Vec::new();
+        let versions = ruby_lang_versions(body).unwrap_drain_errs(&mut errors);
         assert_eq!(
             vec![String::from("4.0.5")],
             versions.iter().map(|v| v.to_string()).collect::<Vec<_>>()
@@ -288,7 +288,8 @@ mod tests {
         "}
         .to_string();
 
-        let (versions, errors) = ruby_lang_versions(body).partition_result_vec();
+        let mut errors = Vec::new();
+        let versions = ruby_lang_versions(body).unwrap_drain_errs(&mut errors);
         assert_eq!(
             vec![String::from("4.0.5")],
             versions.iter().map(|v| v.to_string()).collect::<Vec<_>>()

--- a/shared/src/maybe_err.rs
+++ b/shared/src/maybe_err.rs
@@ -7,24 +7,60 @@
 //! An example would be parsing multiple versions from a file. If one version is unparseable, the program
 //! might still want to continue execution on the ones that were valid rather than returning early.
 //! The structures in this module make such deferred error decision making easier.
+//!
+//! See [`ResultVec`] for the main accumulator type.
 
-/// Extension methods for any iterator of `Result<T, E>` that help accumulate errors instead
-/// of failing on the first one.
+/// Return multiple errors and/or results
 ///
-/// This covers the same ground as itertools' `partition_result`, but without pulling in the
-/// itertools dependency and without the type annotations its iterator-based API requires.
-/// Bring this trait into scope and the methods become available on anything that iterates over
-/// `Result<T, E>` (any [`IntoIterator`]) — [`Vec`], arrays, iterator adaptors, and so on.
+/// Sugared version of `Vec<Result<T, E>>` allowing accumulation of errors:
 ///
 /// ```
-/// use shared::maybe_err::ResultIterExt;
+/// use shared::maybe_err::ResultVec;
 ///
-/// let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse")];
-/// let (oks, errs) = results.partition_result_vec();
-/// assert_eq!(oks, vec![1, 2]);
-/// assert_eq!(errs, vec!["bad", "worse"]);
+/// // Parse every entry, keeping the good values *and* the failures instead of
+/// // bailing on the first unparseable one. The function return type drives the
+/// // `collect`, so no turbofish is needed.
+/// fn parse_versions(raw: &[&str]) -> ResultVec<u32, String> {
+///     raw.iter()
+///         .map(|s| s.parse::<u32>().map_err(|e| format!("{s:?}: {e}")))
+///         .collect()
+/// }
+///
+/// let parsed = parse_versions(&["1", "nope", "3"]);
+///
+/// // Drain the errors into a sink and keep going with the successes.
+/// let mut errors: Vec<String> = Vec::new();
+/// let versions = parsed.unwrap_drain_errs(&mut errors);
+///
+/// assert_eq!(versions, vec![1, 3]);
+/// assert_eq!(errors, vec![r#""nope": invalid digit found in string"#.to_string()]);
 /// ```
-pub trait ResultIterExt<T, E>: IntoIterator<Item = Result<T, E>> + Sized {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResultVec<T, E> {
+    inner: Vec<Result<T, E>>,
+}
+
+impl<T, E> ResultVec<T, E> {
+    /// Return the inner vec
+    ///
+    /// ```
+    /// use shared::maybe_err::ResultVec;
+    ///
+    /// fn call(input: ResultVec<i32, String>) {
+    ///     for item in input.into_inner().into_iter() {
+    ///         eprintln!("Got {:?}", item);
+    ///     }
+    /// }
+    /// ```
+    pub fn into_inner(self) -> Vec<Result<T, E>> {
+        self.inner
+    }
+
+    /// Iterate over the results by reference, without consuming the `ResultVec`.
+    pub fn iter(&self) -> std::slice::Iter<'_, Result<T, E>> {
+        self.inner.iter()
+    }
+
     /// Return the `Ok` values, draining the errors into the provided sink.
     ///
     /// Errors are converted via [`Into`] as they are moved into `errors`, so the sink can
@@ -32,131 +68,102 @@ pub trait ResultIterExt<T, E>: IntoIterator<Item = Result<T, E>> + Sized {
     /// keep going with the successful values while accumulating failures somewhere else.
     ///
     /// ```
-    /// use shared::maybe_err::ResultIterExt;
+    /// use shared::maybe_err::ResultVec;
     ///
-    /// let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse")];
+    /// let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse")]
+    ///     .into_iter()
+    ///     .collect::<ResultVec<_, _>>();
     ///
     /// let mut errors: Vec<String> = Vec::new();
-    /// let oks = results.unwrap_drain(&mut errors);
+    /// let oks = results.unwrap_drain_errs(&mut errors);
     ///
     /// assert_eq!(oks, vec![1, 2]);
     /// assert_eq!(errors, vec!["bad".to_string(), "worse".to_string()]);
     /// ```
+    ///
+    /// Named after the [`Result::unwrap_or`] / [`Result::unwrap_or_else`] family: `unwrap` returns
+    /// the success values (`Vec<T>`) and the suffix names the error strategy — draining each `Err`
+    /// into `sink` rather than substituting a fallback value.
     #[must_use]
-    fn unwrap_drain<X, Item>(self, errors: &mut X) -> Vec<T>
+    pub fn unwrap_drain_errs<X, Item>(self, sink: &mut X) -> Vec<T>
     where
         X: Extend<Item>,
         E: Into<Item>,
     {
-        let (oks, errs) = self.partition_result_vec();
-        errors.extend(errs.into_iter().map(Into::into));
+        let mut oks = Vec::with_capacity(self.inner.len());
+
+        for item in self.inner {
+            match item {
+                Ok(ok) => oks.push(ok),
+                Err(err) => sink.extend(std::iter::once(err.into())),
+            }
+        }
 
         oks
     }
+}
 
-    /// Split the results into successes and errors, preserving order within each group.
-    ///
-    /// This mirrors itertools' `partition_result`: every `Ok` value lands in the first
-    /// `Vec` and every `Err` value in the second, so you can accumulate all failures
-    /// instead of bailing on the first one.
-    ///
-    /// This is a convenience wrapper over [`partition_result_iter`](Self::partition_result_iter) that fixes
-    /// both output collections to `Vec`, so (unlike itertools) you don't need any type
-    /// annotations and don't pull in an extra dependency.
-    ///
-    /// ```
-    /// use shared::maybe_err::ResultIterExt;
-    ///
-    /// let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse")];
-    /// let (oks, errs) = results.partition_result_vec();
-    /// assert_eq!(oks, vec![1, 2]);
-    /// assert_eq!(errs, vec!["bad", "worse"]);
-    /// ```
-    #[must_use]
-    fn partition_result_vec(self) -> (Vec<T>, Vec<E>) {
-        self.partition_result_iter()
-    }
-
-    /// Split the results into successes and errors, collecting each side into a caller-chosen
-    /// collection.
-    ///
-    /// This behaves exactly like itertools' `partition_result`: it is generic over the output
-    /// collections, so you pick what each side collects into (and, like itertools, you'll
-    /// usually need a type annotation to drive that choice). For the common case where both
-    /// sides are `Vec`, reach for [`partition_result_vec`](Self::partition_result_vec) instead
-    /// which doesn't need type annotations.
-    ///
-    /// ```
-    /// use shared::maybe_err::ResultIterExt;
-    /// use std::collections::VecDeque;
-    ///
-    /// let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse")];
-    /// let (oks, errs): (Vec<_>, VecDeque<_>) = results.partition_result_iter();
-    /// assert_eq!(oks, vec![1, 2]);
-    /// assert_eq!(errs, VecDeque::from(vec!["bad", "worse"]));
-    /// ```
-    #[must_use]
-    fn partition_result_iter<A, B>(self) -> (A, B)
-    where
-        A: Default + Extend<T>,
-        B: Default + Extend<E>,
-    {
-        let mut oks = A::default();
-        let mut errs = B::default();
-        for result in self {
-            match result {
-                Ok(value) => oks.extend(std::iter::once(value)),
-                Err(err) => errs.extend(std::iter::once(err)),
-            }
+impl<T, E> FromIterator<Result<T, E>> for ResultVec<T, E> {
+    fn from_iter<I: IntoIterator<Item = Result<T, E>>>(iter: I) -> Self {
+        Self {
+            inner: iter.into_iter().collect(),
         }
-        (oks, errs)
     }
 }
 
-impl<T, E, I> ResultIterExt<T, E> for I where I: IntoIterator<Item = Result<T, E>> {}
+impl<T, E> IntoIterator for ResultVec<T, E> {
+    type Item = Result<T, E>;
+
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+impl<'a, T, E> IntoIterator for &'a ResultVec<T, E> {
+    type Item = &'a Result<T, E>;
+
+    type IntoIter = std::slice::Iter<'a, Result<T, E>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter()
+    }
+}
+
+impl<T, E> From<Vec<Result<T, E>>> for ResultVec<T, E> {
+    fn from(inner: Vec<Result<T, E>>) -> Self {
+        Self { inner }
+    }
+}
 
 #[cfg(test)]
 mod test {
     use super::*;
-
     #[test]
-    fn partition_result_vec_splits_oks_and_errs_in_order() {
-        let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse"), Ok(3)];
-        let (oks, errs) = results.partition_result_vec();
-        assert_eq!(oks, vec![1, 2, 3]);
-        assert_eq!(errs, vec!["bad", "worse"]);
-    }
-
-    #[test]
-    fn unwrap_drain_returns_oks_and_fills_error_sink() {
-        let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse"), Ok(3)];
-
+    fn unwrap_drain_errs_returns_oks_in_order_and_fills_sink() {
+        let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse"), Ok(3)]
+            .into_iter()
+            .collect::<ResultVec<_, _>>();
         let mut errors: Vec<String> = Vec::new();
-        let oks = results.unwrap_drain(&mut errors);
-
+        let oks = results.unwrap_drain_errs(&mut errors);
         assert_eq!(oks, vec![1, 2, 3]);
         assert_eq!(errors, vec!["bad".to_string(), "worse".to_string()]);
     }
 
     #[test]
-    fn partition_result_vec_handles_empty() {
-        let results: Vec<Result<i32, &str>> = vec![];
-        let (oks, errs) = results.partition_result_vec();
+    fn unwrap_drain_errs_handles_empty() {
+        let results: ResultVec<i32, &str> = Vec::new().into();
+        let mut errors: Vec<String> = Vec::new();
+        let oks = results.unwrap_drain_errs(&mut errors);
         assert!(oks.is_empty());
-        assert!(errs.is_empty());
+        assert!(errors.is_empty());
     }
 
     #[test]
-    fn partition_result_vec_works_on_any_into_iterator() {
-        let results: [Result<i32, &str>; 3] = [Ok(1), Err("bad"), Ok(2)];
-        let (oks, errs) = results.partition_result_vec();
-        assert_eq!(oks, vec![1, 2]);
-        assert_eq!(errs, vec!["bad"]);
-
-        let (oks, errs) = (1..=4)
-            .map(|n| if n % 2 == 0 { Ok(n) } else { Err(n) })
-            .partition_result_vec();
-        assert_eq!(oks, vec![2, 4]);
-        assert_eq!(errs, vec![1, 3]);
+    fn from_vec_and_into_inner_round_trip() {
+        let original: Vec<Result<i32, &str>> = vec![Ok(1), Err("bad"), Ok(2)];
+        let round_tripped = ResultVec::from(original.clone()).into_inner();
+        assert_eq!(round_tripped, original);
     }
 }

--- a/shared/src/maybe_err.rs
+++ b/shared/src/maybe_err.rs
@@ -7,765 +7,156 @@
 //! An example would be parsing multiple versions from a file. If one version is unparseable, the program
 //! might still want to continue execution on the ones that were valid rather than returning early.
 //! The structures in this module make such deferred error decision making easier.
-//!
-//! ## Structs
-//!
-//! - [`MaybeErrors`] - Zero or more errors (the empty-able accumulator you push into).
-//! - [`NonEmptyErrors`] - One or more errors (the non-empty value you return).
-//! - [`OkMaybe`] -- A value plus maybe one-or-more errors.
-//!
-//! ## Example
-//!
-//! In a function that returns an [`OkMaybe`], it's common to build an error accumulator
-//! early and delay evaluation of the return result until the end. Push into the
-//! accumulator as you go (or use [`OkMaybe::drain_unwrap`] to drain a sub-result's
-//! errors into it while keeping the value), then hand it the value with
-//! [`MaybeErrors::ok_maybe`]:
-//!
-//! ```
-//! use shared::maybe_err::{MaybeErrors, NonEmptyErrors, OkMaybe};
-//!
-//! /// Parse every input, keeping the ones that succeed and collecting the rest as errors.
-//! fn parse_all(inputs: &[&str]) -> OkMaybe<Vec<u32>, NonEmptyErrors<String>> {
-//!     let mut errors = MaybeErrors::new();
-//!     let mut values = Vec::new();
-//!
-//!     for input in inputs {
-//!         match input.parse::<u32>() {
-//!             Ok(value) => values.push(value),
-//!             Err(err) => errors.push(format!("{input:?}: {err}")),
-//!         }
-//!     }
-//!
-//!     errors.ok_maybe(values)
-//! }
-//!
-//! // All inputs valid: a value and no errors.
-//! assert_eq!(parse_all(&["1", "2", "3"]), OkMaybe(vec![1, 2, 3], None));
-//!
-//! // Some inputs invalid: the good values plus the accumulated errors.
-//! let OkMaybe(values, maybe) = parse_all(&["1", "nope", "3", "also nope"]);
-//! assert_eq!(values, vec![1, 3]);
-//! assert_eq!(maybe.expect("two errors").len().get(), 2);
-//! ```
-//!
-//! ## Guidance
-//!
-//! The error behavior of a function is encoded in its return type:
-//!
-//! - Errors that block producing a value: `Result<T, NonEmptyErrors<E>>`. This represents either a valid
-//!   type `T` or 1 or more errors.
-//! - Errors that never block producing a value — the caller decides whether to surface them:
-//!   `OkMaybe<T, NonEmptyErrors<E>>`. In this representation `T` is always
-//!   available, but there may or may not also be errors. If there are errors, `NonEmptyErrors` represents
-//!   1 or more error.
-//! - Errors that may or may not block: `Result<OkMaybe<T, NonEmptyErrors<E>>, NonEmptyErrors<E>>`.
-//!   - `Ok(OkMaybe(value, None))` -- no errors.
-//!   - `Ok(OkMaybe(value, Some(multi_errors)))` -- error(s) that did not block.
-//!   - `Err(multi_errors)` -- could not produce a value due to error(s).
 
-use std::fmt::{self, Display};
-use std::num::NonZeroUsize;
-
-/// One or more errors, guaranteed non-empty by construction.
+/// Extension methods for any iterator of `Result<T, E>` that help accumulate errors instead
+/// of failing on the first one.
 ///
-/// This is the value you *return* when you have at least one error. If you need to represent
-/// zero or more errors you can use [`MaybeErrors`] instead.
-///
-/// Build the first error with [`NonEmptyErrors::new`], then add more with
-/// [`NonEmptyErrors::push`] or [`Extend`]. To collapse a possibly-empty pile of errors
-/// into `Option<NonEmptyErrors<E>>`, accumulate into a [`MaybeErrors`] instead.
+/// This covers the same ground as itertools' `partition_result`, but without pulling in the
+/// itertools dependency and without the type annotations its iterator-based API requires.
+/// Bring this trait into scope and the methods become available on anything that iterates over
+/// `Result<T, E>` (any [`IntoIterator`]) — [`Vec`], arrays, iterator adaptors, and so on.
 ///
 /// ```
-/// use shared::maybe_err::NonEmptyErrors;
+/// use shared::maybe_err::ResultIterExt;
 ///
-/// let mut multi_errors = NonEmptyErrors::new("first".to_string());
-/// multi_errors.push("second".to_string());
-///
-/// assert_eq!(multi_errors.len().get(), 2);
-/// let collected: Vec<String> = multi_errors.into_iter().collect();
-/// assert_eq!(collected, vec!["first".to_string(), "second".to_string()]);
+/// let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse")];
+/// let (oks, errs) = results.partition_result_vec();
+/// assert_eq!(oks, vec![1, 2]);
+/// assert_eq!(errs, vec!["bad", "worse"]);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NonEmptyErrors<E> {
-    head: E,
-    tail: Vec<E>,
-}
-
-impl<E> NonEmptyErrors<E> {
-    /// Create a non-empty collection from a single error.
+pub trait ResultIterExt<T, E>: IntoIterator<Item = Result<T, E>> + Sized {
+    /// Return the `Ok` values, draining the errors into the provided sink.
+    ///
+    /// Errors are converted via [`Into`] as they are moved into `errors`, so the sink can
+    /// collect a different (e.g. boxed or stringified) error type. Use this when you want to
+    /// keep going with the successful values while accumulating failures somewhere else.
     ///
     /// ```
-    /// use shared::maybe_err::NonEmptyErrors;
+    /// use shared::maybe_err::ResultIterExt;
     ///
-    /// let multi_errors = NonEmptyErrors::new("boom".to_string());
-    /// assert_eq!(multi_errors.len().get(), 1);
+    /// let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse")];
+    ///
+    /// let mut errors: Vec<String> = Vec::new();
+    /// let oks = results.unwrap_drain(&mut errors);
+    ///
+    /// assert_eq!(oks, vec![1, 2]);
+    /// assert_eq!(errors, vec!["bad".to_string(), "worse".to_string()]);
     /// ```
-    pub fn new(first: E) -> Self {
-        NonEmptyErrors {
-            head: first,
-            tail: Vec::new(),
-        }
-    }
-
-    /// Append another error.
-    ///
-    /// ```
-    /// use shared::maybe_err::NonEmptyErrors;
-    ///
-    /// let mut multi_errors = NonEmptyErrors::new("a".to_string());
-    /// multi_errors.push("b".to_string());
-    /// assert_eq!(multi_errors.len().get(), 2);
-    /// ```
-    pub fn push(&mut self, err: E) {
-        self.tail.push(err);
-    }
-
-    /// The number of errors held, always at least one.
-    ///
-    /// Returning [`NonZeroUsize`] surfaces the non-empty guarantee in the type.
-    ///
-    /// ```
-    /// use shared::maybe_err::NonEmptyErrors;
-    ///
-    /// let multi_errors = NonEmptyErrors::new(());
-    /// assert_eq!(multi_errors.len().get(), 1);
-    /// ```
-    pub fn len(&self) -> NonZeroUsize {
-        NonZeroUsize::new(1 + self.tail.len())
-            .expect("NonEmptyErrors always holds at least one error")
-    }
-
-    /// Borrow each error in turn, head first then the rest in push order.
-    ///
-    /// ```
-    /// use shared::maybe_err::NonEmptyErrors;
-    ///
-    /// let mut multi_errors = NonEmptyErrors::new(1);
-    /// multi_errors.push(2);
-    /// multi_errors.push(3);
-    /// assert_eq!(multi_errors.iter().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
-    /// ```
-    pub fn iter(&self) -> std::iter::Chain<std::iter::Once<&E>, std::slice::Iter<'_, E>> {
-        std::iter::once(&self.head).chain(self.tail.iter())
-    }
-}
-
-impl<E> IntoIterator for NonEmptyErrors<E> {
-    type Item = E;
-    type IntoIter = std::iter::Chain<std::iter::Once<E>, std::vec::IntoIter<E>>;
-
-    /// Iterate over every error, head first then the rest in push order.
-    ///
-    /// ```
-    /// use shared::maybe_err::NonEmptyErrors;
-    ///
-    /// let mut multi_errors = NonEmptyErrors::new(1);
-    /// multi_errors.push(2);
-    /// multi_errors.push(3);
-    /// assert_eq!(multi_errors.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
-    /// ```
-    fn into_iter(self) -> Self::IntoIter {
-        std::iter::once(self.head).chain(self.tail)
-    }
-}
-
-impl<'a, E> IntoIterator for &'a NonEmptyErrors<E> {
-    type Item = &'a E;
-    type IntoIter = std::iter::Chain<std::iter::Once<&'a E>, std::slice::Iter<'a, E>>;
-
-    /// Borrowing iteration, so `for err in &multi_errors` works.
-    ///
-    /// ```
-    /// use shared::maybe_err::NonEmptyErrors;
-    ///
-    /// let mut multi_errors = NonEmptyErrors::new(1);
-    /// multi_errors.push(2);
-    /// let seen: Vec<i32> = (&multi_errors).into_iter().copied().collect();
-    /// assert_eq!(seen, vec![1, 2]);
-    /// ```
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<E> Extend<E> for NonEmptyErrors<E> {
-    /// Append many errors at once. Also serves as a "combine": extend one
-    /// `NonEmptyErrors` with the contents of another via its [`IntoIterator`].
-    ///
-    /// ```
-    /// use shared::maybe_err::NonEmptyErrors;
-    ///
-    /// let mut a = NonEmptyErrors::new(1);
-    /// let mut b = NonEmptyErrors::new(2);
-    /// b.push(3);
-    /// a.extend(b);
-    /// assert_eq!(a.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
-    /// ```
-    fn extend<I: IntoIterator<Item = E>>(&mut self, iter: I) {
-        self.tail.extend(iter);
-    }
-}
-
-impl<E> From<E> for NonEmptyErrors<E> {
-    /// Lift a single error into a `NonEmptyErrors`, enabling `.into()` and `?`.
-    ///
-    /// ```
-    /// use shared::maybe_err::NonEmptyErrors;
-    ///
-    /// let errs: NonEmptyErrors<String> = "boom".to_string().into();
-    /// assert_eq!(errs.len().get(), 1);
-    /// ```
-    fn from(err: E) -> Self {
-        NonEmptyErrors::new(err)
-    }
-}
-
-impl<E: Display> Display for NonEmptyErrors<E> {
-    /// A single error renders as that error; multiple render as a numbered block.
-    ///
-    /// ```
-    /// use shared::maybe_err::NonEmptyErrors;
-    ///
-    /// let one = NonEmptyErrors::new("only".to_string());
-    /// assert_eq!(one.to_string(), "only");
-    ///
-    /// let mut many = NonEmptyErrors::new("first".to_string());
-    /// many.push("second".to_string());
-    /// assert_eq!(many.to_string(), "2 errors:\n  1. first\n  2. second");
-    /// ```
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let len = self.len();
-        if len.get() == 1 {
-            write!(f, "{}", self.head)
-        } else {
-            write!(f, "{} errors:", len)?;
-            for (index, err) in self.iter().enumerate() {
-                write!(f, "\n  {}. {}", index + 1, err)?;
-            }
-            Ok(())
-        }
-    }
-}
-
-impl<E: std::error::Error + 'static> std::error::Error for NonEmptyErrors<E> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}
-
-/// Zero or more errors: the empty-able accumulator you push into.
-///
-/// It starts empty and, once you are done accumulating, [`MaybeErrors::into_option`] collapses it into
-/// `Option<NonEmptyErrors<E>>`: `None` means there were no errors, `Some` means one or
-/// more.
-///
-/// ```
-/// use shared::maybe_err::{NonEmptyErrors, MaybeErrors};
-///
-/// let mut errors = MaybeErrors::new();
-/// assert!(errors.is_empty());
-///
-/// errors.push("nope".to_string());
-/// errors.push("also nope".to_string());
-///
-/// let multi_errors: NonEmptyErrors<String> = errors.into_option().expect("two errors");
-/// assert_eq!(multi_errors.len().get(), 2);
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MaybeErrors<E>(Option<NonEmptyErrors<E>>);
-
-impl<E> MaybeErrors<E> {
-    /// Create an empty accumulator.
-    ///
-    /// ```
-    /// use shared::maybe_err::MaybeErrors;
-    ///
-    /// let errors: MaybeErrors<String> = MaybeErrors::new();
-    /// assert!(errors.is_empty());
-    /// ```
-    pub fn new() -> Self {
-        MaybeErrors(None)
-    }
-
-    /// Accumulate one error. The first push creates the underlying
-    /// [`NonEmptyErrors`]; later pushes append to it.
-    ///
-    /// ```
-    /// use shared::maybe_err::MaybeErrors;
-    ///
-    /// let mut errors = MaybeErrors::new();
-    /// errors.push("boom".to_string());
-    /// assert!(!errors.is_empty());
-    /// ```
-    pub fn push(&mut self, err: E) {
-        match &mut self.0 {
-            Some(multi_errors) => multi_errors.push(err),
-            none => *none = Some(NonEmptyErrors::new(err)),
-        }
-    }
-
-    /// Whether any error has been accumulated yet.
-    ///
-    /// ```
-    /// use shared::maybe_err::MaybeErrors;
-    ///
-    /// let mut errors = MaybeErrors::new();
-    /// assert!(errors.is_empty());
-    /// errors.push(());
-    /// assert!(!errors.is_empty());
-    /// ```
-    pub fn is_empty(&self) -> bool {
-        self.0.is_none()
-    }
-
-    /// How many errors have been accumulated, `0` when empty.
-    ///
-    /// ```
-    /// use shared::maybe_err::MaybeErrors;
-    ///
-    /// let mut errors = MaybeErrors::new();
-    /// assert_eq!(errors.len(), 0);
-    /// errors.push("a".to_string());
-    /// errors.push("b".to_string());
-    /// assert_eq!(errors.len(), 2);
-    /// ```
-    pub fn len(&self) -> usize {
-        self.0
-            .as_ref()
-            .map_or(0, |multi_errors| multi_errors.len().get())
-    }
-
-    /// Borrow each accumulated error in turn; yields nothing when empty.
-    ///
-    /// ```
-    /// use shared::maybe_err::MaybeErrors;
-    ///
-    /// let mut errors = MaybeErrors::new();
-    /// errors.push("a".to_string());
-    /// errors.push("b".to_string());
-    /// let seen: Vec<&String> = errors.iter().collect();
-    /// assert_eq!(seen, vec![&"a".to_string(), &"b".to_string()]);
-    /// ```
-    pub fn iter(&self) -> impl Iterator<Item = &E> {
-        self.into_iter()
-    }
-
-    /// Collapse into `Option<NonEmptyErrors<E>>`: `None` if empty, otherwise the
-    /// accumulated non-empty [`NonEmptyErrors`].
-    ///
-    /// ```
-    /// use shared::maybe_err::MaybeErrors;
-    ///
-    /// let empty: MaybeErrors<String> = MaybeErrors::new();
-    /// assert!(empty.into_option().is_none());
-    ///
-    /// let mut errors = MaybeErrors::new();
-    /// errors.push("boom".to_string());
-    /// assert!(errors.into_option().is_some());
-    /// ```
-    pub fn into_option(self) -> Option<NonEmptyErrors<E>> {
-        self.0
-    }
-
-    /// Pair the accumulated errors with a value, producing an [`OkMaybe`].
-    ///
-    /// This is the bridge from the accumulate phase to the return phase: once
-    /// you have finished pushing into a `MaybeErrors` and have produced a value,
-    /// `ok_maybe` collapses the accumulator into the error half of an
-    /// `OkMaybe<T, NonEmptyErrors<E>>`. An empty accumulator yields
-    /// `OkMaybe(value, None)`; a non-empty one yields `OkMaybe(value,
-    /// Some(multi_errors))`.
-    ///
-    /// ```
-    /// use shared::maybe_err::{MaybeErrors, OkMaybe};
-    ///
-    /// let errors: MaybeErrors<String> = MaybeErrors::new();
-    /// assert_eq!(errors.ok_maybe(1), OkMaybe(1, None));
-    ///
-    /// let mut errors = MaybeErrors::new();
-    /// errors.push("boom".to_string());
-    /// let OkMaybe(value, maybe) = errors.ok_maybe(2);
-    /// assert_eq!(value, 2);
-    /// assert_eq!(maybe.expect("one error").len().get(), 1);
-    /// ```
-    pub fn ok_maybe<T>(self, t: T) -> OkMaybe<T, NonEmptyErrors<E>> {
-        match self.0 {
-            Some(inner) => OkMaybe(t, Some(inner)),
-            None => OkMaybe(t, None),
-        }
-    }
-}
-
-impl<E> Default for MaybeErrors<E> {
-    fn default() -> Self {
-        MaybeErrors::new()
-    }
-}
-
-impl<'a, E> IntoIterator for &'a MaybeErrors<E> {
-    type Item = &'a E;
-    type IntoIter = std::iter::Flatten<
-        std::option::IntoIter<std::iter::Chain<std::iter::Once<&'a E>, std::slice::Iter<'a, E>>>,
-    >;
-
-    /// Borrowing iteration, so `for err in &errors` works. An empty accumulator
-    /// yields no items.
-    ///
-    /// ```
-    /// use shared::maybe_err::MaybeErrors;
-    ///
-    /// let empty: MaybeErrors<String> = MaybeErrors::new();
-    /// assert_eq!((&empty).into_iter().count(), 0);
-    ///
-    /// let mut errors = MaybeErrors::new();
-    /// errors.push(1);
-    /// errors.push(2);
-    /// let seen: Vec<i32> = (&errors).into_iter().copied().collect();
-    /// assert_eq!(seen, vec![1, 2]);
-    /// ```
-    fn into_iter(self) -> Self::IntoIter {
-        self.0
-            .as_ref()
-            .map(IntoIterator::into_iter)
-            .into_iter()
-            .flatten()
-    }
-}
-
-impl<E> Extend<E> for MaybeErrors<E> {
-    /// Accumulate many errors at once. This is what makes a `MaybeErrors` a
-    /// valid [`OkMaybe::drain_unwrap`] target.
-    ///
-    /// ```
-    /// use shared::maybe_err::MaybeErrors;
-    ///
-    /// let mut errors = MaybeErrors::new();
-    /// errors.extend(vec!["a".to_string(), "b".to_string()]);
-    /// assert_eq!(errors.into_option().expect("two errors").len().get(), 2);
-    /// ```
-    fn extend<I: IntoIterator<Item = E>>(&mut self, iter: I) {
-        for err in iter {
-            self.push(err);
-        }
-    }
-}
-
-impl<E> FromIterator<E> for MaybeErrors<E> {
-    /// Collect errors into an accumulator, so `iter.collect::<MaybeErrors<_>>()` works.
-    ///
-    /// ```
-    /// use shared::maybe_err::MaybeErrors;
-    ///
-    /// let errors: MaybeErrors<String> =
-    ///     vec!["a".to_string(), "b".to_string()].into_iter().collect();
-    /// assert_eq!(errors.len(), 2);
-    ///
-    /// let empty: MaybeErrors<String> = std::iter::empty().collect();
-    /// assert!(empty.is_empty());
-    /// ```
-    fn from_iter<I: IntoIterator<Item = E>>(iter: I) -> Self {
-        let mut errors = MaybeErrors::new();
-        errors.extend(iter);
-        errors
-    }
-}
-
-/// A value paired with maybe an error.
-///
-/// A replacement for `Result<T, E>` when we always want to produce `T` and
-/// sometimes emit error(s) alongside it.
-///
-/// A function returning `Result<T, E>` may finish without ever constructing a
-/// `T`. In a function returning `OkMaybe<T, E>`: every return path must
-/// produce a `T`. This rules out `?`-style short-circuit returns and
-/// reinforces error accumulation at the type-signature level.
-///
-/// Variants:
-///
-/// - `OkMaybe(value, None)` carries a value with no error
-/// - `OkMaybe(value, Some(err))` carries a value AND an error.
-///
-/// To return multiple errors we suggest using `OkMaybe<T, NonEmptyErrors<E>>`.
-///
-/// ```
-/// use shared::maybe_err::OkMaybe;
-///
-/// let ok: OkMaybe<i32, String> = OkMaybe(1, None);
-/// assert_eq!(ok.to_result(), Ok(1));
-///
-/// let bad: OkMaybe<i32, String> = OkMaybe(2, Some("nope".to_string()));
-/// assert_eq!(bad.to_result(), Err("nope".to_string()));
-/// ```
-///
-/// In a function that returns an [`OkMaybe`], it's common to build an error accumulator
-/// early and delay evaluation of the return result until the end. Push into the
-/// accumulator as you go (or [`OkMaybe::drain_unwrap`] sub-results into it), then
-/// hand it the value with [`MaybeErrors::ok_maybe`]:
-///
-/// ```
-/// use shared::maybe_err::{MaybeErrors, NonEmptyErrors, OkMaybe};
-///
-/// /// Parse every input, keeping the ones that succeed and collecting the rest as errors.
-/// fn parse_all(inputs: &[&str]) -> OkMaybe<Vec<u32>, NonEmptyErrors<String>> {
-///     let mut errors = MaybeErrors::new();
-///     let mut values = Vec::new();
-///
-///     for input in inputs {
-///         match input.parse::<u32>() {
-///             Ok(value) => values.push(value),
-///             Err(err) => errors.push(format!("{input:?}: {err}")),
-///         }
-///     }
-///
-///     errors.ok_maybe(values)
-/// }
-///
-/// // All inputs valid: a value and no errors.
-/// assert_eq!(parse_all(&["1", "2", "3"]), OkMaybe(vec![1, 2, 3], None));
-///
-/// // Some inputs invalid: the good values plus the accumulated errors.
-/// let OkMaybe(values, maybe) = parse_all(&["1", "nope", "3", "also nope"]);
-/// assert_eq!(values, vec![1, 3]);
-/// assert_eq!(maybe.expect("two errors").len().get(), 2);
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OkMaybe<T, E>(pub T, pub Option<E>);
-
-impl<T, E> OkMaybe<T, E> {
-    /// Convert into a `Result`: `Some` error becomes `Err`, `None` becomes
-    /// `Ok(value)`. Use this when a partial value is not usable.
-    ///
-    /// ```
-    /// use shared::maybe_err::OkMaybe;
-    ///
-    /// assert_eq!(OkMaybe::<_, String>((), None).to_result(), Ok(()));
-    /// assert_eq!(OkMaybe((), Some("e".to_string())).to_result(), Err("e".to_string()));
-    /// ```
-    pub fn to_result(self) -> Result<T, E> {
-        let OkMaybe(value, maybe) = self;
-        match maybe {
-            Some(err) => Err(err),
-            None => Ok(value),
-        }
-    }
-
-    /// Drain any error into an accumulator and return the value.
-    ///
-    /// The error type must be [`IntoIterator`] (as [`NonEmptyErrors`] is), so its
-    /// errors can be pushed into any [`Extend`] target such as a
-    /// [`MaybeErrors`] or a plain `Vec`. This is the key ergonomic for
-    /// accumulating across many fallible steps in a loop.
-    ///
-    /// The target chooses the error type it stores: each drained error is
-    /// converted with [`Into`], so a sub-result with a concrete error type can
-    /// be funneled into a wider accumulator such as
-    /// `MaybeErrors<Box<dyn std::error::Error>>`. When the types already match,
-    /// the conversion is the no-op reflexive [`From`].
-    ///
-    /// ```
-    /// use shared::maybe_err::{NonEmptyErrors, MaybeErrors, OkMaybe};
-    ///
-    /// let mut errors: MaybeErrors<String> = MaybeErrors::new();
-    ///
-    /// // Same type drains as-is.
-    /// let value = OkMaybe(10, Some(NonEmptyErrors::new("bad".to_string())))
-    ///     .drain_unwrap(&mut errors);
-    /// assert_eq!(value, 10);
-    /// assert!(!errors.is_empty());
-    ///
-    /// // Source errors are `&str`, accumulator holds `String`: converted via `Into`.
-    /// let value = OkMaybe(20, Some(NonEmptyErrors::new("worse")))
-    ///     .drain_unwrap(&mut errors);
-    /// assert_eq!(value, 20);
-    /// assert_eq!(errors.len(), 2);
-    /// ```
-    pub fn drain_unwrap<G, H>(self, push_to: &mut impl Extend<H>) -> T
+    #[must_use]
+    fn unwrap_drain<X, Item>(self, errors: &mut X) -> Vec<T>
     where
-        E: IntoIterator<Item = G>,
-        G: Into<H>,
+        X: Extend<Item>,
+        E: Into<Item>,
     {
-        let OkMaybe(value, maybe) = self;
-        if let Some(err) = maybe {
-            push_to.extend(err.into_iter().map(Into::into));
+        let (oks, errs) = self.partition_result_vec();
+        errors.extend(errs.into_iter().map(Into::into));
+
+        oks
+    }
+
+    /// Split the results into successes and errors, preserving order within each group.
+    ///
+    /// This mirrors itertools' `partition_result`: every `Ok` value lands in the first
+    /// `Vec` and every `Err` value in the second, so you can accumulate all failures
+    /// instead of bailing on the first one.
+    ///
+    /// This is a convenience wrapper over [`partition_result_iter`](Self::partition_result_iter) that fixes
+    /// both output collections to `Vec`, so (unlike itertools) you don't need any type
+    /// annotations and don't pull in an extra dependency.
+    ///
+    /// ```
+    /// use shared::maybe_err::ResultIterExt;
+    ///
+    /// let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse")];
+    /// let (oks, errs) = results.partition_result_vec();
+    /// assert_eq!(oks, vec![1, 2]);
+    /// assert_eq!(errs, vec!["bad", "worse"]);
+    /// ```
+    #[must_use]
+    fn partition_result_vec(self) -> (Vec<T>, Vec<E>) {
+        self.partition_result_iter()
+    }
+
+    /// Split the results into successes and errors, collecting each side into a caller-chosen
+    /// collection.
+    ///
+    /// This behaves exactly like itertools' `partition_result`: it is generic over the output
+    /// collections, so you pick what each side collects into (and, like itertools, you'll
+    /// usually need a type annotation to drive that choice). For the common case where both
+    /// sides are `Vec`, reach for [`partition_result_vec`](Self::partition_result_vec) instead
+    /// which doesn't need type annotations.
+    ///
+    /// ```
+    /// use shared::maybe_err::ResultIterExt;
+    /// use std::collections::VecDeque;
+    ///
+    /// let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse")];
+    /// let (oks, errs): (Vec<_>, VecDeque<_>) = results.partition_result_iter();
+    /// assert_eq!(oks, vec![1, 2]);
+    /// assert_eq!(errs, VecDeque::from(vec!["bad", "worse"]));
+    /// ```
+    #[must_use]
+    fn partition_result_iter<A, B>(self) -> (A, B)
+    where
+        A: Default + Extend<T>,
+        B: Default + Extend<E>,
+    {
+        let mut oks = A::default();
+        let mut errs = B::default();
+        for result in self {
+            match result {
+                Ok(value) => oks.extend(std::iter::once(value)),
+                Err(err) => errs.extend(std::iter::once(err)),
+            }
         }
-        value
+        (oks, errs)
     }
 }
+
+impl<T, E, I> ResultIterExt<T, E> for I where I: IntoIterator<Item = Result<T, E>> {}
 
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
-    fn multi_errors_len_starts_at_one() {
-        let multi_errors = NonEmptyErrors::new("a");
-        assert_eq!(multi_errors.len().get(), 1);
+    fn partition_result_vec_splits_oks_and_errs_in_order() {
+        let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse"), Ok(3)];
+        let (oks, errs) = results.partition_result_vec();
+        assert_eq!(oks, vec![1, 2, 3]);
+        assert_eq!(errs, vec!["bad", "worse"]);
     }
 
     #[test]
-    fn multi_errors_push_grows_len() {
-        let mut multi_errors = NonEmptyErrors::new("a");
-        multi_errors.push("b");
-        multi_errors.push("c");
-        assert_eq!(multi_errors.len().get(), 3);
-    }
+    fn unwrap_drain_returns_oks_and_fills_error_sink() {
+        let results = vec![Ok(1), Err("bad"), Ok(2), Err("worse"), Ok(3)];
 
-    #[test]
-    fn multi_errors_into_iter_is_head_then_tail() {
-        let mut multi_errors = NonEmptyErrors::new(1);
-        multi_errors.push(2);
-        multi_errors.push(3);
-        assert_eq!(multi_errors.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
-    }
-
-    #[test]
-    fn multi_errors_extend_appends() {
-        let mut multi_errors = NonEmptyErrors::new(1);
-        multi_errors.extend(vec![2, 3]);
-
-        let mut other = NonEmptyErrors::new(4);
-        other.push(5);
-        multi_errors.extend(other);
-
-        assert_eq!(
-            multi_errors.into_iter().collect::<Vec<_>>(),
-            vec![1, 2, 3, 4, 5]
-        );
-    }
-
-    #[test]
-    fn multi_errors_display_single() {
-        let multi_errors = NonEmptyErrors::new("only".to_string());
-        assert_eq!(multi_errors.to_string(), "only");
-    }
-
-    #[test]
-    fn multi_errors_display_multiple() {
-        let mut multi_errors = NonEmptyErrors::new("first".to_string());
-        multi_errors.push("second".to_string());
-        assert_eq!(
-            multi_errors.to_string(),
-            "2 errors:\n  1. first\n  2. second"
-        );
-    }
-
-    #[test]
-    fn multi_errors_is_usable_as_boxed_error() {
-        #[derive(Debug)]
-        struct MyError(&'static str);
-        impl Display for MyError {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{}", self.0)
-            }
-        }
-        impl std::error::Error for MyError {}
-
-        let multi_errors = NonEmptyErrors::new(MyError("boom"));
-        let boxed: Box<dyn std::error::Error> = Box::new(multi_errors);
-        assert_eq!(boxed.to_string(), "boom");
-        assert!(boxed.source().is_none());
-    }
-
-    #[test]
-    fn maybe_errors_empty_into_option_is_none() {
-        let errors: MaybeErrors<String> = MaybeErrors::new();
-        assert!(errors.is_empty());
-        assert!(errors.into_option().is_none());
-    }
-
-    #[test]
-    fn maybe_errors_push_then_into_option_is_some() {
-        let mut errors = MaybeErrors::new();
-        errors.push("a".to_string());
-        errors.push("b".to_string());
-        assert!(!errors.is_empty());
-
-        let multi_errors = errors.into_option().expect("two errors accumulated");
-        assert_eq!(multi_errors.len().get(), 2);
-    }
-
-    #[test]
-    fn maybe_errors_default_is_empty() {
-        let errors: MaybeErrors<String> = MaybeErrors::default();
-        assert!(errors.is_empty());
-    }
-
-    #[test]
-    fn maybe_errors_extend_accumulates() {
-        let mut errors = MaybeErrors::new();
-        errors.extend(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
-        assert_eq!(errors.into_option().expect("three errors").len().get(), 3);
-    }
-
-    #[test]
-    fn ok_maybe_to_result_ok_arm() {
-        let value: OkMaybe<i32, String> = OkMaybe(7, None);
-        assert_eq!(value.to_result(), Ok(7));
-    }
-
-    #[test]
-    fn ok_maybe_to_result_err_arm() {
-        let value: OkMaybe<i32, String> = OkMaybe(7, Some("bad".to_string()));
-        assert_eq!(value.to_result(), Err("bad".to_string()));
-    }
-
-    #[test]
-    fn ok_maybe_push_unwrap_drains_into_maybe_errors() {
-        let mut errors: MaybeErrors<String> = MaybeErrors::new();
-
-        let first = OkMaybe::<i32, NonEmptyErrors<String>>(1, None).drain_unwrap(&mut errors);
-        let second =
-            OkMaybe(2, Some(NonEmptyErrors::new("boom".to_string()))).drain_unwrap(&mut errors);
-
-        assert_eq!(first, 1);
-        assert_eq!(second, 2);
-
-        let multi_errors = errors.into_option().expect("one error accumulated");
-        assert_eq!(
-            multi_errors.into_iter().collect::<Vec<_>>(),
-            vec!["boom".to_string()]
-        );
-    }
-
-    #[test]
-    fn ok_maybe_push_unwrap_accepts_vec_target() {
         let mut errors: Vec<String> = Vec::new();
-        let value = OkMaybe("data", Some(NonEmptyErrors::new("oops".to_string())))
-            .drain_unwrap(&mut errors);
-        assert_eq!(value, "data");
-        assert_eq!(errors, vec!["oops".to_string()]);
+        let oks = results.unwrap_drain(&mut errors);
+
+        assert_eq!(oks, vec![1, 2, 3]);
+        assert_eq!(errors, vec!["bad".to_string(), "worse".to_string()]);
     }
 
     #[test]
-    fn non_empty_errors_from_single_error() {
-        let multi_errors: NonEmptyErrors<String> = "boom".to_string().into();
-        assert_eq!(multi_errors.len().get(), 1);
-        assert_eq!(
-            multi_errors.into_iter().collect::<Vec<_>>(),
-            vec!["boom".to_string()]
-        );
+    fn partition_result_vec_handles_empty() {
+        let results: Vec<Result<i32, &str>> = vec![];
+        let (oks, errs) = results.partition_result_vec();
+        assert!(oks.is_empty());
+        assert!(errs.is_empty());
     }
 
     #[test]
-    fn maybe_errors_from_iter_non_empty() {
-        let errors: MaybeErrors<String> =
-            vec!["a".to_string(), "b".to_string()].into_iter().collect();
-        assert_eq!(errors.len(), 2);
-        assert_eq!(
-            errors
-                .into_option()
-                .expect("two errors")
-                .into_iter()
-                .collect::<Vec<_>>(),
-            vec!["a".to_string(), "b".to_string()]
-        );
-    }
+    fn partition_result_vec_works_on_any_into_iterator() {
+        let results: [Result<i32, &str>; 3] = [Ok(1), Err("bad"), Ok(2)];
+        let (oks, errs) = results.partition_result_vec();
+        assert_eq!(oks, vec![1, 2]);
+        assert_eq!(errs, vec!["bad"]);
 
-    #[test]
-    fn maybe_errors_from_iter_empty() {
-        let empty: MaybeErrors<String> = std::iter::empty().collect();
-        assert!(empty.is_empty());
-        assert!(empty.into_option().is_none());
+        let (oks, errs) = (1..=4)
+            .map(|n| if n % 2 == 0 { Ok(n) } else { Err(n) })
+            .partition_result_vec();
+        assert_eq!(oks, vec![2, 4]);
+        assert_eq!(errs, vec![1, 3]);
     }
 }


### PR DESCRIPTION
This is an exploration of alternative design decisions. The structs this is replacing were originally introduced in https://github.com/heroku/docker-heroku-ruby-builder/pull/152 and @colincasey mentioned there was some room for improvement. This PR explores different ways to have `Vec<Result<T,E>>` serve as an error accumulator. 