### PR TITLE
Add docker linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ jobs:
       - name: Run ShellCheck
         run: shellcheck *.sh -x
 
+  dockerfile_lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          recursive: true
+          dockerfile: Dockerfile
+
   lint:
     runs-on: ubuntu-24.04
     steps:

--- a/dockerfiles/jruby_check/Dockerfile
+++ b/dockerfiles/jruby_check/Dockerfile
@@ -6,6 +6,6 @@ USER root
 
 # hadolint ignore=DL3008
 RUN apt-get update -y \
-    && apt-get install -y default-jre default-jdk \
+    && apt-get install -y --no-install-recommends default-jre default-jdk \
     && rm -rf /var/lib/apt/lists/*
 USER heroku

--- a/dockerfiles/jruby_check/Dockerfile
+++ b/dockerfiles/jruby_check/Dockerfile
@@ -5,5 +5,7 @@ FROM heroku/heroku:${STACK_VERSION}-build
 USER root
 
 # hadolint ignore=DL3008
-RUN apt-get update -y; apt-get install default-jre default-jdk -y
+RUN apt-get update -y \
+    && apt-get install -y default-jre default-jdk \
+    && rm -rf /var/lib/apt/lists/*
 USER heroku

--- a/dockerfiles/jruby_check/Dockerfile
+++ b/dockerfiles/jruby_check/Dockerfile
@@ -3,5 +3,7 @@ FROM heroku/heroku:${STACK_VERSION}-build
 
 # Only apt needs root: installing system packages writes to root-owned paths
 USER root
+
+# hadolint ignore=DL3008
 RUN apt-get update -y; apt-get install default-jre default-jdk -y
 USER heroku

--- a/dockerfiles/jruby_check/Dockerfile
+++ b/dockerfiles/jruby_check/Dockerfile
@@ -1,5 +1,7 @@
 ARG STACK_VERSION="24"
 FROM heroku/heroku:${STACK_VERSION}-build
 
+# Only apt needs root: installing system packages writes to root-owned paths
 USER root
 RUN apt-get update -y; apt-get install default-jre default-jdk -y
+USER heroku

--- a/dockerfiles/ruby_build/Dockerfile
+++ b/dockerfiles/ruby_build/Dockerfile
@@ -1,11 +1,13 @@
 ARG STACK_VERSION="24"
 FROM heroku/heroku:${STACK_VERSION}-build
 
+# Only apt needs root: installing system packages writes to root-owned paths
 USER root
-
 RUN apt-get update -y && apt-get install -y libreadline-dev ruby
+USER heroku
+
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="/home/heroku/.cargo/bin:${PATH}"
 RUN rustup update
 
 WORKDIR /tmp/workdir/

--- a/dockerfiles/ruby_build/Dockerfile
+++ b/dockerfiles/ruby_build/Dockerfile
@@ -3,17 +3,19 @@ FROM heroku/heroku:${STACK_VERSION}-build
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Only apt needs root: installing system packages writes to root-owned paths
+# This is a throwaway build image, not a runtime image. It intentionally stays
+# root: the build writes into a host-owned bind mount (needs root on Linux) and
+# rustup/cargo must be installed for the same user that runs the build.
+# hadolint ignore=DL3002
 USER root
 
 # hadolint ignore=DL3008
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends libreadline-dev ruby \
     && rm -rf /var/lib/apt/lists/*
-USER heroku
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH="/home/heroku/.cargo/bin:${PATH}"
+ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup update
 
 WORKDIR /tmp/workdir/

--- a/dockerfiles/ruby_build/Dockerfile
+++ b/dockerfiles/ruby_build/Dockerfile
@@ -5,6 +5,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Only apt needs root: installing system packages writes to root-owned paths
 USER root
+
+# hadolint ignore=DL3008
 RUN apt-get update -y && apt-get install -y libreadline-dev ruby
 USER heroku
 

--- a/dockerfiles/ruby_build/Dockerfile
+++ b/dockerfiles/ruby_build/Dockerfile
@@ -1,6 +1,8 @@
 ARG STACK_VERSION="24"
 FROM heroku/heroku:${STACK_VERSION}-build
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Only apt needs root: installing system packages writes to root-owned paths
 USER root
 RUN apt-get update -y && apt-get install -y libreadline-dev ruby

--- a/dockerfiles/ruby_build/Dockerfile
+++ b/dockerfiles/ruby_build/Dockerfile
@@ -7,7 +7,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 USER root
 
 # hadolint ignore=DL3008
-RUN apt-get update -y && apt-get install -y libreadline-dev ruby
+RUN apt-get update -y \
+    && apt-get install -y libreadline-dev ruby \
+    && rm -rf /var/lib/apt/lists/*
 USER heroku
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/dockerfiles/ruby_build/Dockerfile
+++ b/dockerfiles/ruby_build/Dockerfile
@@ -8,7 +8,7 @@ USER root
 
 # hadolint ignore=DL3008
 RUN apt-get update -y \
-    && apt-get install -y libreadline-dev ruby \
+    && apt-get install -y --no-install-recommends libreadline-dev ruby \
     && rm -rf /var/lib/apt/lists/*
 USER heroku
 

--- a/make_ruby.sh
+++ b/make_ruby.sh
@@ -21,9 +21,12 @@ set -o xtrace
 mkdir -p "$(dirname "$OUT_TAR")"
 
 # Docker issue with permissions
-# The container runs as root, so directories it creates are root-owned.
-# The host process needs write access to both the arch dir and its parent
-# (for legacy non-arch copies on heroku-22).
+#
+# These dirs are created by the container (whatever `USER` the Dockerfile sets).
+# The host process later copies files in as a different uid.
+# - On macOS this works because Docker Desktop remaps mount ownership to the host user.
+# - On linux this does not work because bind mounts share ownership by raw uid, so
+#   a container-owned dir isn't writable by the host's uid.
 chmod a+w "$(dirname "$OUT_TAR")"
 chmod a+w "$(dirname "$(dirname "$OUT_TAR")")"
 mkdir -p /tmp/source


### PR DESCRIPTION
I spotted a spurious failure. https://github.com/heroku/docker-heroku-ruby-builder/actions/runs/29478373417 failed, but the next run succeeded. In that investigation, my mechanical friend noted that the shell was not set to catch a pipefail and casually mentioned it would have failed `hadolint`.

This is my first time with this tool. I'm trying to take as many suggestions as possible. I'm treating it like shellcheck, hopefully to give some more rigor and checks to the process.